### PR TITLE
feat: Phase 1 合成地形マップ + 1 ホール設計

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to street-golf are documented in this file. The format is ba
 ## [Unreleased]
 
 ### Added
+- Phase 1 synthetic course ([#2](https://github.com/kako-jun/street-golf/issues/2)).
+  `src/course.rs` introduces `Course`, which implements both `termray::TileMap`
+  and `termray::HeightMap` for a hand-drawn 200m × 40m layout (rooftop tee,
+  fairway, rough, two bunkers, water hazard, green with pin). `Course::generate(seed)`
+  is seed-deterministic; corner heights are precomputed so the `HeightMap`
+  continuity contract is automatically satisfied. `examples/fly_through.rs` lets
+  you walk the course (`cargo run --release --example fly_through`) to verify
+  the terrain before ball physics lands in Phase 2.
 - Project skeleton on top of termray 0.3 and rapier3d 0.32
   ([#1](https://github.com/kako-jun/street-golf/issues/1)). `cargo run` blanks the
   framebuffer to a meadow green for a brief moment and exits cleanly — Phase 1+ will

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Single-crate binary depending on the external [`termray`](https://github.com/kak
 
 - `src/main.rs` — entry point, input loop, frame presentation (crossterm half-block output)
 - `src/lib.rs` — public surface. Empty at Phase 0, will grow with each phase
-- `src/course.rs` (Phase 1) — `Course`: termray::HeightMap implementation for the terrain, tee / fairway / green / hole layout
+- `src/course.rs` (Phase 1 — 実装済) — `Course`: implements `termray::TileMap` + `termray::HeightMap`. Hand-drawn 200×40 layout with tee / fairway / rough / bunkers / water / green + pin. Per-corner floor heights are precomputed with a seed-derived low-frequency noise base, a flat 20m rooftop tee, a water surface at -0.2m (solid), and a green bowl centered on the pin.
 - `src/physics.rs` (Phase 2) — rapier3d rigid-body world, ball state, course collider generation, step-and-sample integration
 - `src/shot.rs` (Phase 3) — shot input (club selection, aim, power) and the shot → ball-flight → rest sequence
 - `src/hud.rs` (Phase 4) — score card, club picker, wind / distance / lie indicators
@@ -27,7 +27,7 @@ cargo fmt --all
 
 ## Current phase
 
-Phase 0 — skeleton. `cargo run` blanks the framebuffer to a dark meadow green for ~0.8 s then exits cleanly. The Cargo manifest (with `rapier3d` dependency reserved for Phase 2), CI / release workflows, and documentation are in place; Phase 1+ will make it interactive.
+Phase 1 — synthetic course. `cargo run --release --example fly_through` opens a 200m × 40m hand-drawn course (tee / fairway / rough / two bunkers / water hazard / green + pin) on top of termray 0.3's sloped-floor rendering. `Course::generate(42)` is seed-deterministic; the walkthrough lets you verify the terrain before ball physics land in Phase 2. `src/main.rs` still runs the Phase 0 splash — it stays untouched until Phase 2 wires rapier3d in.
 
 ## Roadmap
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,19 +79,52 @@ Phase 1 (#2)  Course heightmap ───┬┘
 - **Phase 4** adds `hud.rs`: score card, club indicator, hole-out detection, round end.
 - **Phase 5+** replaces the synthetic course with real-world data pulled from OpenStreetMap (geometry) and SRTM (elevation).
 
-## Current state (Phase 0)
+## Current state (Phase 1)
 
-`src/main.rs` currently:
+`src/course.rs` now defines `Course` — a synthetic 1-hole course that implements both `termray::TileMap` and `termray::HeightMap`. `examples/fly_through.rs` drives it as an interactive walkthrough so the terrain can be verified visually before Phase 2 introduces ball physics.
 
-1. Reads terminal size via `crossterm::terminal::size`.
-2. Allocates a `termray::Framebuffer` at full terminal width × 2×(rows−2) pixels (half-block rendering doubles vertical resolution).
-3. Clears it to a dark meadow green.
-4. Enters the alternate screen, hides the cursor, enables raw mode.
-5. Writes one frame using half-block characters (`▀`): top pixel → foreground RGB, bottom pixel → background RGB.
-6. Sleeps ~800 ms so the user can see the blank frame.
-7. Restores the terminal and exits.
+`src/main.rs` still runs the Phase 0 splash and stays that way until Phase 2. The Phase 1 entry point is the example:
 
-There is no course, no ball, no input handling yet — those arrive with the phases above.
+```bash
+cargo run --release --example fly_through
+```
+
+### Map layout
+
+World coordinates: 1 tile = 1m. Map is 200 × 40 tiles; world origin `(0, 0)` is the NW corner, `y` increases southward.
+
+| Region | Tile | Extent (inclusive) | Surface height |
+|---|---|---|---|
+| Outer border | `TILE_WALL` (1) | x ∈ {0, 199} ∪ y ∈ {0, 39} | 0.0m (not rendered from inside) |
+| Tee | `TILE_TEE` (3) | x=3..6, y=18..21 | flat 20.0m rooftop |
+| Fairway | `TILE_FAIRWAY` (4) | x=10..179, y=15..24 | `base_height` (±0.4m) |
+| Rough | `TILE_ROUGH` (5) | fill elsewhere inside the border | `base_height` (±0.4m) |
+| Bunker 1 | `TILE_BUNKER` (6) | x=80..83, y=19..21 | `base_height − 1.5m` |
+| Bunker 2 | `TILE_BUNKER` (6) | x=140..142, y=17..20 | `base_height − 1.5m` |
+| Water | `TILE_WATER` (8) | x=105..109, y=17..21 | −0.2m, **solid** |
+| Green | `TILE_GREEN` (7) | x=180..194, y=16..23 | `base_height * 0.3 − 0.3 * exp(−d² / 6.0)` where `d` = distance to pin |
+| Pin (sprite) | — | `(190.5, 20.5)` | — |
+| Tee spawn (camera) | — | `(5.0, 20.0, 20.5)` | z = rooftop + 0.5m eye |
+
+`base_height(cx, cy) = 0.4 * amp_scale * (0.6 * sin(0.07·cx + phase_x) + 0.4 * sin(0.11·cy + phase_y))`, where `phase_x`, `phase_y`, `amp_scale` are sampled from `StdRng::seed_from_u64(seed)`. `Course::generate(seed)` is deterministic — same seed always yields identical per-corner height arrays.
+
+### Corner priority
+
+The 201 × 41 corner grid is shared between adjacent tiles, so each corner is classified by **the highest-priority tile among its four neighboring cells** (NW / NE / SW / SE). Priority (highest first):
+
+1. `TILE_WALL` — forces `floor = 0.0`
+2. `TILE_TEE` — forces `floor = 20.0` (guarantees the 4×4 tee is strictly flat)
+3. `TILE_BUNKER`
+4. `TILE_WATER`
+5. `TILE_GREEN`
+6. `TILE_FAIRWAY`
+7. `TILE_ROUGH`
+
+`ceil[corner] = floor[corner] + 3.0m` everywhere.
+
+### is_solid contract
+
+`TILE_WALL`, `TILE_VOID`, and `TILE_WATER` are solid. Out-of-bounds tiles return `true` (per `TileMap` contract). Tee / fairway / rough / bunker / green are walkable.
 
 ## External dependencies
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,7 +50,7 @@ user input ──► shot parameters (club, aim, power)
 | Capability | termray version | Used by |
 |---|---|---|
 | Sloped floors / HeightMap | 0.3.0 | `course.rs` (Phase 1) |
-| Sprites | 0.2.0 | `physics.rs` ↔ renderer glue (Phase 2) |
+| Sprites | 0.2.0 | Phase 1 example (`fly_through` ピン), Phase 2+ 物理 ↔ renderer glue |
 | Text labels above sprites | 0.3.0 | `course.rs` (pin), `hud.rs` (Phase 4) |
 
 All three have already shipped in termray 0.3, so street-golf can depend on a stable release line from Phase 1 onward without patching the upstream engine.

--- a/examples/fly_through.rs
+++ b/examples/fly_through.rs
@@ -27,11 +27,11 @@ use crossterm::terminal::{
 };
 
 use street_golf::{
-    Course, TILE_BUNKER, TILE_FAIRWAY, TILE_GREEN, TILE_ROUGH, TILE_TEE, TILE_WATER,
+    Course, TILE_BUNKER, TILE_FAIRWAY, TILE_GREEN, TILE_ROUGH, TILE_TEE, TILE_WATER, step_x, step_y,
 };
 use termray::{
-    Camera, Color, FloorTexturer, Framebuffer, HitSide, Sprite, SpriteArt, SpriteDef, TILE_WALL,
-    TileMap, TileType, WallTexturer, project_sprites, render_floor_ceiling, render_sprites,
+    Camera, Color, FloorTexturer, Framebuffer, HeightMap, HitSide, Sprite, SpriteArt, SpriteDef,
+    TILE_WALL, TileType, WallTexturer, project_sprites, render_floor_ceiling, render_sprites,
     render_walls,
 };
 
@@ -161,32 +161,6 @@ fn present(fb: &Framebuffer, status: &str) -> std::io::Result<()> {
     stdout.flush()
 }
 
-fn step_x(course: &Course, x: f64, y: f64, dx: f64, radius: f64) -> (f64, bool) {
-    if dx == 0.0 {
-        return (x, false);
-    }
-    let nx = x + dx;
-    let probe_x = nx + dx.signum() * radius;
-    if course.is_solid(probe_x.floor() as i32, y.floor() as i32) {
-        (x, true)
-    } else {
-        (nx, false)
-    }
-}
-
-fn step_y(course: &Course, x: f64, y: f64, dy: f64, radius: f64) -> (f64, bool) {
-    if dy == 0.0 {
-        return (y, false);
-    }
-    let ny = y + dy;
-    let probe_y = ny + dy.signum() * radius;
-    if course.is_solid(x.floor() as i32, probe_y.floor() as i32) {
-        (y, true)
-    } else {
-        (ny, false)
-    }
-}
-
 fn main() -> std::io::Result<()> {
     let (cols, rows) = size()?;
     let fb_w = cols as usize;
@@ -287,10 +261,7 @@ fn main() -> std::io::Result<()> {
         let cy = ny.floor() as i32;
         let u = nx - cx as f64;
         let v = ny - cy as f64;
-        let floor_h = {
-            use termray::HeightMap;
-            course.cell_heights(cx, cy).sample_floor(u, v)
-        };
+        let floor_h = course.cell_heights(cx, cy).sample_floor(u, v);
         let new_z = floor_h + 0.5;
 
         let new_yaw = cam.angle + dyaw;

--- a/examples/fly_through.rs
+++ b/examples/fly_through.rs
@@ -1,0 +1,323 @@
+//! Phase 1 の合成コースを歩き回るためのウォークスルー例。
+//!
+//! `cargo run --release --example fly_through` で起動。`Course::generate(42)` の
+//! 200×40 合成コースを termray で描画し、ティーのルーフトップから打ち下ろすビューに
+//! 赤い旗竿（ピン）のスプライトが遠方に見える。Phase 2 以降でボール物理と
+//! ショット入力が入るまで、地形を確認するためのツール。
+//!
+//! 操作:
+//! - `w` / `s` — 前後移動
+//! - `a` / `d` — 左右ストレイフ
+//! - `q` / `e` — 左右旋回
+//! - `r` / `f` — 上下ピッチ
+//! - `esc` — 終了
+
+use std::io::{Write, stdout};
+use std::time::{Duration, Instant};
+
+use crossterm::cursor::{Hide, MoveTo, Show};
+use crossterm::event::{Event, KeyCode, poll, read};
+use crossterm::execute;
+use crossterm::style::{
+    Color as CtColor, Print, ResetColor, SetBackgroundColor, SetForegroundColor,
+};
+use crossterm::terminal::{
+    Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode,
+    enable_raw_mode, size,
+};
+
+use street_golf::{
+    Course, TILE_BUNKER, TILE_FAIRWAY, TILE_GREEN, TILE_ROUGH, TILE_TEE, TILE_WATER,
+};
+use termray::{
+    Camera, Color, FloorTexturer, Framebuffer, HitSide, Sprite, SpriteArt, SpriteDef, TILE_WALL,
+    TileMap, TileType, WallTexturer, project_sprites, render_floor_ceiling, render_sprites,
+    render_walls,
+};
+
+const MAX_DISTANCE: f64 = 60.0;
+const PIN_SPRITE_TYPE: u8 = 1;
+
+/// タイル種に応じて床色を切り替える描画者。`Course` への参照を持たせて、
+/// ワールド座標 → タイル ID → 色のマッピングを閉じ込める。
+struct CourseScene<'a> {
+    course: &'a Course,
+}
+
+impl<'a> WallTexturer for CourseScene<'a> {
+    fn sample_wall(
+        &self,
+        _tile: TileType,
+        _wall_x: f64,
+        _wall_y: f64,
+        side: HitSide,
+        brightness: f64,
+        _tile_hash: u32,
+    ) -> Color {
+        let base = match side {
+            HitSide::Vertical => Color::rgb(160, 140, 100),
+            HitSide::Horizontal => Color::rgb(130, 110, 80),
+        };
+        base.darken(brightness)
+    }
+}
+
+impl<'a> FloorTexturer for CourseScene<'a> {
+    fn sample_floor(&self, wx: f64, wy: f64, brightness: f64) -> Color {
+        let cx = wx.floor() as i32;
+        let cy = wy.floor() as i32;
+        let color = match self.course.tile_at(cx, cy) {
+            Some(TILE_FAIRWAY) => Color::rgb(100, 160, 80),
+            Some(TILE_ROUGH) => Color::rgb(70, 110, 55),
+            Some(TILE_BUNKER) => Color::rgb(220, 200, 150),
+            Some(TILE_GREEN) => Color::rgb(120, 180, 90),
+            Some(TILE_TEE) => Color::rgb(110, 140, 100),
+            Some(TILE_WATER) => Color::rgb(50, 100, 180),
+            Some(TILE_WALL) => Color::rgb(160, 140, 100),
+            _ => Color::rgb(70, 110, 55),
+        };
+        color.darken(brightness)
+    }
+
+    fn sample_ceiling(&self, _wx: f64, _wy: f64, brightness: f64) -> Color {
+        Color::rgb(130, 170, 210).darken(brightness)
+    }
+}
+
+struct PinArt {
+    def: SpriteDef,
+}
+
+impl PinArt {
+    fn new() -> Self {
+        // 縦長の旗竿。`#` がピンの棒と旗布、`.` が透明。
+        // ピンの高さ（height_scale）を大きめにして遠くからも見える。
+        const PATTERN: &[&str] = &[
+            "##.", "##.", "##.", "#..", "#..", "#..", "#..", "#..", "#..", "#..",
+        ];
+        Self {
+            def: SpriteDef {
+                pattern: PATTERN,
+                height_scale: 2.0,
+                float_offset_scale: 0.0,
+            },
+        }
+    }
+}
+
+impl SpriteArt for PinArt {
+    fn art(&self, sprite_type: u8) -> Option<&SpriteDef> {
+        if sprite_type == PIN_SPRITE_TYPE {
+            Some(&self.def)
+        } else {
+            None
+        }
+    }
+
+    fn color(&self, _sprite_type: u8) -> Color {
+        Color::rgb(220, 30, 30)
+    }
+}
+
+fn tile_name(t: Option<TileType>) -> &'static str {
+    match t {
+        Some(TILE_TEE) => "tee",
+        Some(TILE_FAIRWAY) => "fairway",
+        Some(TILE_ROUGH) => "rough",
+        Some(TILE_BUNKER) => "bunker",
+        Some(TILE_GREEN) => "green",
+        Some(TILE_WATER) => "water",
+        Some(TILE_WALL) => "wall",
+        Some(_) => "?",
+        None => "oob",
+    }
+}
+
+fn present(fb: &Framebuffer, status: &str) -> std::io::Result<()> {
+    let mut stdout = stdout();
+    execute!(stdout, MoveTo(0, 0))?;
+    for y in (0..fb.height()).step_by(2) {
+        for x in 0..fb.width() {
+            let top = fb.get_pixel(x, y);
+            let bot = fb.get_pixel(x, (y + 1).min(fb.height() - 1));
+            execute!(
+                stdout,
+                SetForegroundColor(CtColor::Rgb {
+                    r: top.r,
+                    g: top.g,
+                    b: top.b
+                }),
+                SetBackgroundColor(CtColor::Rgb {
+                    r: bot.r,
+                    g: bot.g,
+                    b: bot.b
+                }),
+                Print("▀"),
+            )?;
+        }
+        execute!(stdout, ResetColor, Print("\r\n"))?;
+    }
+    execute!(stdout, ResetColor, Print(status))?;
+    stdout.flush()
+}
+
+fn step_x(course: &Course, x: f64, y: f64, dx: f64, radius: f64) -> (f64, bool) {
+    if dx == 0.0 {
+        return (x, false);
+    }
+    let nx = x + dx;
+    let probe_x = nx + dx.signum() * radius;
+    if course.is_solid(probe_x.floor() as i32, y.floor() as i32) {
+        (x, true)
+    } else {
+        (nx, false)
+    }
+}
+
+fn step_y(course: &Course, x: f64, y: f64, dy: f64, radius: f64) -> (f64, bool) {
+    if dy == 0.0 {
+        return (y, false);
+    }
+    let ny = y + dy;
+    let probe_y = ny + dy.signum() * radius;
+    if course.is_solid(x.floor() as i32, probe_y.floor() as i32) {
+        (y, true)
+    } else {
+        (ny, false)
+    }
+}
+
+fn main() -> std::io::Result<()> {
+    let (cols, rows) = size()?;
+    let fb_w = cols as usize;
+    let fb_h = (rows as usize).saturating_sub(2) * 2;
+
+    let course = Course::generate(42);
+    let scene = CourseScene { course: &course };
+    let pin_art = PinArt::new();
+
+    let (tee_x, tee_y, tee_z) = course.tee_spawn();
+    let (pin_x, pin_y) = course.pin();
+
+    let mut cam = Camera::with_z(tee_x, tee_y, tee_z, 0.0, 70f64.to_radians());
+    let mut fb = Framebuffer::new(fb_w, fb_h);
+
+    let mut vx = 0.0_f64;
+    let mut vy = 0.0_f64;
+    let accel = 12.0;
+    let friction = 6.0;
+    let turn_rate = 2.4;
+    let pitch_rate = 1.5;
+    let pitch_limit = 0.9;
+    let radius = 0.2;
+
+    // 旗竿。Phase 1 では 1 本のみ。
+    let sprites = vec![Sprite {
+        x: pin_x,
+        y: pin_y,
+        sprite_type: PIN_SPRITE_TYPE,
+    }];
+
+    enable_raw_mode()?;
+    execute!(stdout(), EnterAlternateScreen, Hide, Clear(ClearType::All))?;
+
+    let mut last = Instant::now();
+    let mut running = true;
+
+    while running {
+        let now = Instant::now();
+        let dt = (now - last).as_secs_f64().min(0.05);
+        last = now;
+
+        let mut dvx = 0.0;
+        let mut dvy = 0.0;
+        let mut dyaw = 0.0;
+        let mut dpitch = 0.0;
+        while poll(Duration::from_millis(0))? {
+            if let Event::Key(key) = read()? {
+                let fwd = cam.forward();
+                let right = cam.right();
+                match key.code {
+                    KeyCode::Esc => {
+                        running = false;
+                        break;
+                    }
+                    KeyCode::Char('w') => {
+                        dvx += fwd.x * accel * dt;
+                        dvy += fwd.y * accel * dt;
+                    }
+                    KeyCode::Char('s') => {
+                        dvx -= fwd.x * accel * dt;
+                        dvy -= fwd.y * accel * dt;
+                    }
+                    KeyCode::Char('d') => {
+                        dvx += right.x * accel * dt;
+                        dvy += right.y * accel * dt;
+                    }
+                    KeyCode::Char('a') => {
+                        dvx -= right.x * accel * dt;
+                        dvy -= right.y * accel * dt;
+                    }
+                    KeyCode::Char('q') => dyaw -= turn_rate * dt,
+                    KeyCode::Char('e') => dyaw += turn_rate * dt,
+                    KeyCode::Char('r') => dpitch += pitch_rate * dt,
+                    KeyCode::Char('f') => dpitch -= pitch_rate * dt,
+                    _ => {}
+                }
+            }
+        }
+
+        vx += dvx;
+        vy += dvy;
+        let decay = (-friction * dt).exp();
+        vx *= decay;
+        vy *= decay;
+
+        let (nx, blocked_x) = step_x(&course, cam.x, cam.y, vx * dt, radius);
+        let (ny, blocked_y) = step_y(&course, nx, cam.y, vy * dt, radius);
+        if blocked_x {
+            vx = 0.0;
+        }
+        if blocked_y {
+            vy = 0.0;
+        }
+
+        // 足元の地形高さを bilinear でサンプリング。起伏に追従する。
+        let cx = nx.floor() as i32;
+        let cy = ny.floor() as i32;
+        let u = nx - cx as f64;
+        let v = ny - cy as f64;
+        let floor_h = {
+            use termray::HeightMap;
+            course.cell_heights(cx, cy).sample_floor(u, v)
+        };
+        let new_z = floor_h + 0.5;
+
+        let new_yaw = cam.angle + dyaw;
+        let new_pitch = (cam.pitch + dpitch).clamp(-pitch_limit, pitch_limit);
+        cam.set_pose(nx, ny, new_yaw);
+        cam.set_z(new_z);
+        cam.set_pitch(new_pitch);
+
+        fb.clear(Color::default());
+        let rays = cam.cast_all_rays(&course, fb_w, MAX_DISTANCE);
+        render_floor_ceiling(&mut fb, &rays, &scene, &course, &cam, MAX_DISTANCE);
+        render_walls(&mut fb, &rays, &scene, &course, &cam, MAX_DISTANCE);
+
+        let projected = project_sprites(&sprites, &cam, &course, fb_w, fb_h);
+        render_sprites(&mut fb, &projected, &rays, &pin_art, MAX_DISTANCE);
+
+        let name = tile_name(course.tile_at(cx, cy));
+        let status = format!(
+            "x={:5.1} y={:5.1} z={:5.2} tile={name} [wasd qe / rf=pitch esc=quit]",
+            cam.x, cam.y, cam.z
+        );
+        present(&fb, &status)?;
+
+        std::thread::sleep(Duration::from_millis(16));
+    }
+
+    execute!(stdout(), Show, LeaveAlternateScreen)?;
+    disable_raw_mode()?;
+    Ok(())
+}

--- a/src/collide.rs
+++ b/src/collide.rs
@@ -1,0 +1,103 @@
+//! 軸分離の衝突判定ヘルパ。
+//!
+//! カメラやボールが 2D マップ上を動くときに使う、X 軸と Y 軸それぞれの
+//! 1 ステップ進行関数。`radius` は進行方向の probe オフセットで、
+//! ちょうど壁を抜けて角に引っかからないようにするためのもの。
+
+use termray::TileMap;
+
+/// `dx` 方向に 1 ステップ進めた後の新しい X 座標と、壁にぶつかったかを返す。
+///
+/// - `dx == 0.0` の場合は即座に `(x, false)` を返す。
+/// - 進行先のタイル `(probe_x.floor(), y.floor())` が `is_solid` なら移動せず
+///   `(x, true)` を返す（呼び出し側は速度を 0 にする想定）。
+pub fn step_x<M: TileMap>(map: &M, x: f64, y: f64, dx: f64, radius: f64) -> (f64, bool) {
+    if dx == 0.0 {
+        return (x, false);
+    }
+    let nx = x + dx;
+    let probe_x = nx + dx.signum() * radius;
+    if map.is_solid(probe_x.floor() as i32, y.floor() as i32) {
+        (x, true)
+    } else {
+        (nx, false)
+    }
+}
+
+/// `dy` 方向に 1 ステップ進めた後の新しい Y 座標と、壁にぶつかったかを返す。
+/// [`step_x`] と対称。
+pub fn step_y<M: TileMap>(map: &M, x: f64, y: f64, dy: f64, radius: f64) -> (f64, bool) {
+    if dy == 0.0 {
+        return (y, false);
+    }
+    let ny = y + dy;
+    let probe_y = ny + dy.signum() * radius;
+    if map.is_solid(x.floor() as i32, probe_y.floor() as i32) {
+        (y, true)
+    } else {
+        (ny, false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Course;
+
+    #[test]
+    fn step_x_blocks_against_solid() {
+        let c = Course::generate(42);
+        // (0, 20) は外周壁で solid。x=1.5 から左に動こうとすると probe_x が x=0 領域に入り blocked。
+        let (nx, blocked) = step_x(&c, 1.5, 20.0, -0.8, 0.2);
+        assert!(blocked, "movement toward border wall should be blocked");
+        assert!((nx - 1.5).abs() < 1e-9, "x must not advance when blocked");
+    }
+
+    #[test]
+    fn step_x_passes_through_empty() {
+        let c = Course::generate(42);
+        // フェアウェイ内 (60, 20) 周辺は solid ではない。
+        let (nx, blocked) = step_x(&c, 60.0, 20.0, 0.3, 0.2);
+        assert!(!blocked, "movement inside fairway should not be blocked");
+        assert!(
+            (nx - 60.3).abs() < 1e-9,
+            "x must advance by dx when clear, got {nx}"
+        );
+    }
+
+    #[test]
+    fn step_y_blocks_against_solid() {
+        let c = Course::generate(42);
+        // y=1.5 から上に動くと y=0 の外周壁に probe がぶつかる。
+        let (ny, blocked) = step_y(&c, 60.0, 1.5, -0.8, 0.2);
+        assert!(blocked, "movement toward border wall should be blocked");
+        assert!((ny - 1.5).abs() < 1e-9, "y must not advance when blocked");
+    }
+
+    #[test]
+    fn step_y_passes_through_empty() {
+        let c = Course::generate(42);
+        let (ny, blocked) = step_y(&c, 60.0, 20.0, 0.3, 0.2);
+        assert!(!blocked, "movement inside fairway should not be blocked");
+        assert!(
+            (ny - 20.3).abs() < 1e-9,
+            "y must advance by dy when clear, got {ny}"
+        );
+    }
+
+    #[test]
+    fn step_x_zero_is_noop() {
+        let c = Course::generate(42);
+        let (nx, blocked) = step_x(&c, 60.0, 20.0, 0.0, 0.2);
+        assert!(!blocked);
+        assert!((nx - 60.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn step_y_zero_is_noop() {
+        let c = Course::generate(42);
+        let (ny, blocked) = step_y(&c, 60.0, 20.0, 0.0, 0.2);
+        assert!(!blocked);
+        assert!((ny - 20.0).abs() < 1e-9);
+    }
+}

--- a/src/course.rs
+++ b/src/course.rs
@@ -1,0 +1,409 @@
+//! Phase 1 の合成ゴルフコース。
+//!
+//! 200×40 タイルのグリッドに、ティー・フェアウェイ・ラフ・バンカー・ウォーター・
+//! グリーンを手書きで配置する。高さはコーナー単位（201×41）でプリコンピュートし、
+//! [`HeightMap`] の continuity contract を自動で満たす。
+//!
+//! ティー矩形（`x=3..=6, y=18..=21`）は完全に平坦な `20.0m` のルーフトップ。
+//! そこから踏み出すと地面はフェアウェイ帯（±0.4m 起伏）に落ちる。バンカーは
+//! 窪み、ウォーターは固体（Phase 1 ではハザード判定は描画のみ）、グリーンは
+//! ピン (190.5, 20.5) を最低点にした椀。
+
+use rand::Rng;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use termray::{CornerHeights, HeightMap, TILE_VOID, TILE_WALL, TileMap, TileType};
+
+/// ティーグラウンド。平坦 `20.0m` のルーフトップとして扱う。
+pub const TILE_TEE: TileType = 3;
+/// フェアウェイ。base_height の起伏がそのまま出る。
+pub const TILE_FAIRWAY: TileType = 4;
+/// ラフ。フェアウェイと同じ高さ、描画のみ色替え。
+pub const TILE_ROUGH: TileType = 5;
+/// バンカー。base_height から 1.5m 窪む。
+pub const TILE_BUNKER: TileType = 6;
+/// グリーン。ホールを最低点とする椀。
+pub const TILE_GREEN: TileType = 7;
+/// ウォーターハザード。Phase 1 では solid 扱い。
+pub const TILE_WATER: TileType = 8;
+
+const MAP_W: usize = 200;
+const MAP_H: usize = 40;
+const CORNER_W: usize = MAP_W + 1;
+const CORNER_H: usize = MAP_H + 1;
+
+const TEE_X: std::ops::RangeInclusive<i32> = 3..=6;
+const TEE_Y: std::ops::RangeInclusive<i32> = 18..=21;
+const FAIRWAY_X: std::ops::RangeInclusive<i32> = 10..=179;
+const FAIRWAY_Y: std::ops::RangeInclusive<i32> = 15..=24;
+const BUNKER1_X: std::ops::RangeInclusive<i32> = 80..=83;
+const BUNKER1_Y: std::ops::RangeInclusive<i32> = 19..=21;
+const BUNKER2_X: std::ops::RangeInclusive<i32> = 140..=142;
+const BUNKER2_Y: std::ops::RangeInclusive<i32> = 17..=20;
+const WATER_X: std::ops::RangeInclusive<i32> = 105..=109;
+const WATER_Y: std::ops::RangeInclusive<i32> = 17..=21;
+const GREEN_X: std::ops::RangeInclusive<i32> = 180..=194;
+const GREEN_Y: std::ops::RangeInclusive<i32> = 16..=23;
+
+const TEE_FLOOR_HEIGHT: f64 = 20.0;
+const CEILING_OFFSET: f64 = 3.0;
+const PIN_X: f64 = 190.5;
+const PIN_Y: f64 = 20.5;
+const EYE_HEIGHT: f64 = 0.5;
+
+/// Phase 1 の合成コース。
+pub struct Course {
+    seed: u64,
+    tiles: Vec<TileType>,
+    corner_floor: Vec<f64>,
+    corner_ceil: Vec<f64>,
+}
+
+impl Course {
+    /// `seed` で高さ場の位相を決めてコースを生成する。同じ seed で呼ぶと
+    /// `corner_floor` / `corner_ceil` は完全一致する。
+    pub fn generate(seed: u64) -> Self {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let phase_x: f64 = rng.random_range(0.0..std::f64::consts::TAU);
+        let phase_y: f64 = rng.random_range(0.0..std::f64::consts::TAU);
+        let amp_scale: f64 = rng.random_range(0.8..1.2);
+
+        let tiles = build_tiles();
+        let (corner_floor, corner_ceil) = build_corner_heights(&tiles, phase_x, phase_y, amp_scale);
+
+        Self {
+            seed,
+            tiles,
+            corner_floor,
+            corner_ceil,
+        }
+    }
+
+    /// コース生成に使われた seed。
+    pub fn seed(&self) -> u64 {
+        self.seed
+    }
+
+    /// ピン（ホール）の (x, y) ワールド座標。タイル中心。
+    pub fn pin(&self) -> (f64, f64) {
+        (PIN_X, PIN_Y)
+    }
+
+    /// ティーから打つときのカメラ初期位置 (x, y, z)。
+    /// z はルーフトップ高さ + アイレベル。
+    pub fn tee_spawn(&self) -> (f64, f64, f64) {
+        (5.0, 20.0, TEE_FLOOR_HEIGHT + EYE_HEIGHT)
+    }
+
+    /// `(cx, cy)` のタイル種（グリッド座標、i32）。範囲外は `None`。
+    pub fn tile_at(&self, cx: i32, cy: i32) -> Option<TileType> {
+        if cx < 0 || cy < 0 || (cx as usize) >= MAP_W || (cy as usize) >= MAP_H {
+            return None;
+        }
+        Some(self.tiles[cy as usize * MAP_W + cx as usize])
+    }
+}
+
+fn build_tiles() -> Vec<TileType> {
+    let mut tiles = vec![TILE_ROUGH; MAP_W * MAP_H];
+    // 外周壁
+    for x in 0..MAP_W {
+        tiles[x] = TILE_WALL;
+        tiles[(MAP_H - 1) * MAP_W + x] = TILE_WALL;
+    }
+    for y in 0..MAP_H {
+        tiles[y * MAP_W] = TILE_WALL;
+        tiles[y * MAP_W + (MAP_W - 1)] = TILE_WALL;
+    }
+    // フェアウェイ帯
+    paint_rect(&mut tiles, &FAIRWAY_X, &FAIRWAY_Y, TILE_FAIRWAY);
+    // バンカー
+    paint_rect(&mut tiles, &BUNKER1_X, &BUNKER1_Y, TILE_BUNKER);
+    paint_rect(&mut tiles, &BUNKER2_X, &BUNKER2_Y, TILE_BUNKER);
+    // ウォーター
+    paint_rect(&mut tiles, &WATER_X, &WATER_Y, TILE_WATER);
+    // グリーン
+    paint_rect(&mut tiles, &GREEN_X, &GREEN_Y, TILE_GREEN);
+    // ティー（フェアウェイより外側、最後に塗って優先）
+    paint_rect(&mut tiles, &TEE_X, &TEE_Y, TILE_TEE);
+    tiles
+}
+
+fn paint_rect(
+    tiles: &mut [TileType],
+    xs: &std::ops::RangeInclusive<i32>,
+    ys: &std::ops::RangeInclusive<i32>,
+    tile: TileType,
+) {
+    for y in ys.clone() {
+        for x in xs.clone() {
+            if x < 0 || y < 0 || (x as usize) >= MAP_W || (y as usize) >= MAP_H {
+                continue;
+            }
+            tiles[y as usize * MAP_W + x as usize] = tile;
+        }
+    }
+}
+
+fn tile_of(tiles: &[TileType], cx: i32, cy: i32) -> Option<TileType> {
+    if cx < 0 || cy < 0 || (cx as usize) >= MAP_W || (cy as usize) >= MAP_H {
+        return None;
+    }
+    Some(tiles[cy as usize * MAP_W + cx as usize])
+}
+
+/// コーナー優先順位。数値が大きいほど優先。壁は最優先で floor=0.0 を強制する。
+fn tile_priority(tile: TileType) -> u32 {
+    match tile {
+        TILE_WALL => 100,
+        TILE_TEE => 90,
+        TILE_BUNKER => 80,
+        TILE_WATER => 70,
+        TILE_GREEN => 60,
+        TILE_FAIRWAY => 50,
+        TILE_ROUGH => 40,
+        _ => 10,
+    }
+}
+
+/// コーナー `(cx, cy)` を代表するタイル種。NW/NE/SW/SE の 4 セルから
+/// 優先度最大のものを返す。
+fn corner_tile(tiles: &[TileType], cx: i32, cy: i32) -> TileType {
+    let candidates = [
+        tile_of(tiles, cx - 1, cy - 1),
+        tile_of(tiles, cx, cy - 1),
+        tile_of(tiles, cx - 1, cy),
+        tile_of(tiles, cx, cy),
+    ];
+    let mut best = TILE_WALL;
+    let mut best_prio = 0u32;
+    let mut any = false;
+    for c in candidates.into_iter().flatten() {
+        let p = tile_priority(c);
+        if !any || p > best_prio {
+            best = c;
+            best_prio = p;
+            any = true;
+        }
+    }
+    if any { best } else { TILE_WALL }
+}
+
+fn base_height(cx: f64, cy: f64, phase_x: f64, phase_y: f64, amp_scale: f64) -> f64 {
+    // 低周波 sin 波 2 本で ±0.4m 程度の起伏。
+    let hx = (cx * 0.07 + phase_x).sin();
+    let hy = (cy * 0.11 + phase_y).sin();
+    0.4 * amp_scale * (hx * 0.6 + hy * 0.4)
+}
+
+fn corner_floor_at(
+    tiles: &[TileType],
+    cx: i32,
+    cy: i32,
+    phase_x: f64,
+    phase_y: f64,
+    amp_scale: f64,
+) -> f64 {
+    let tile = corner_tile(tiles, cx, cy);
+    let fx = cx as f64;
+    let fy = cy as f64;
+    match tile {
+        TILE_WALL | TILE_VOID => 0.0,
+        TILE_TEE => TEE_FLOOR_HEIGHT,
+        TILE_BUNKER => base_height(fx, fy, phase_x, phase_y, amp_scale) - 1.5,
+        TILE_WATER => -0.2,
+        TILE_GREEN => {
+            let dx = fx - PIN_X;
+            let dy = fy - PIN_Y;
+            let d2 = dx * dx + dy * dy;
+            base_height(fx, fy, phase_x, phase_y, amp_scale) * 0.3 - 0.3 * (-d2 / 6.0).exp()
+        }
+        _ => base_height(fx, fy, phase_x, phase_y, amp_scale),
+    }
+}
+
+fn build_corner_heights(
+    tiles: &[TileType],
+    phase_x: f64,
+    phase_y: f64,
+    amp_scale: f64,
+) -> (Vec<f64>, Vec<f64>) {
+    let mut floor = vec![0.0; CORNER_W * CORNER_H];
+    let mut ceil = vec![0.0; CORNER_W * CORNER_H];
+    for cy in 0..CORNER_H {
+        for cx in 0..CORNER_W {
+            let f = corner_floor_at(tiles, cx as i32, cy as i32, phase_x, phase_y, amp_scale);
+            floor[cy * CORNER_W + cx] = f;
+            ceil[cy * CORNER_W + cx] = f + CEILING_OFFSET;
+        }
+    }
+    (floor, ceil)
+}
+
+fn corner_index(cx: i32, cy: i32) -> Option<usize> {
+    if cx < 0 || cy < 0 || (cx as usize) >= CORNER_W || (cy as usize) >= CORNER_H {
+        return None;
+    }
+    Some(cy as usize * CORNER_W + cx as usize)
+}
+
+impl TileMap for Course {
+    fn width(&self) -> usize {
+        MAP_W
+    }
+
+    fn height(&self) -> usize {
+        MAP_H
+    }
+
+    fn get(&self, x: i32, y: i32) -> Option<TileType> {
+        self.tile_at(x, y)
+    }
+
+    fn is_solid(&self, x: i32, y: i32) -> bool {
+        match self.tile_at(x, y) {
+            None => true,
+            Some(TILE_WALL) | Some(TILE_VOID) | Some(TILE_WATER) => true,
+            Some(_) => false,
+        }
+    }
+}
+
+impl HeightMap for Course {
+    fn cell_heights(&self, x: i32, y: i32) -> CornerHeights {
+        let sample = |cx: i32, cy: i32| -> (f64, f64) {
+            if let Some(i) = corner_index(cx, cy) {
+                (self.corner_floor[i], self.corner_ceil[i])
+            } else {
+                (0.0, CEILING_OFFSET)
+            }
+        };
+        let (f_nw, c_nw) = sample(x, y);
+        let (f_ne, c_ne) = sample(x + 1, y);
+        let (f_sw, c_sw) = sample(x, y + 1);
+        let (f_se, c_se) = sample(x + 1, y + 1);
+        CornerHeights {
+            floor: [f_nw, f_ne, f_sw, f_se],
+            ceil: [c_nw, c_ne, c_sw, c_se],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_seed_produces_identical_corner_heights() {
+        let a = Course::generate(42);
+        let b = Course::generate(42);
+        assert_eq!(a.corner_floor, b.corner_floor);
+        assert_eq!(a.corner_ceil, b.corner_ceil);
+    }
+
+    #[test]
+    fn different_seed_diverges() {
+        let a = Course::generate(42);
+        let b = Course::generate(43);
+        assert_ne!(a.corner_floor, b.corner_floor);
+    }
+
+    #[test]
+    fn tee_corners_are_flat_twenty() {
+        let c = Course::generate(42);
+        // ティー矩形は x=3..=6, y=18..=21。タイル中心でも、タイル内部コーナー
+        // (x=4..=6, y=19..=21) でも高さ 20.0 のはず。優先順位ルールが効いて
+        // いれば境界コーナー (x=3, y=18 等) もティー扱いで 20.0 になる。
+        for cy in 18..=22 {
+            for cx in 3..=7 {
+                let idx = corner_index(cx, cy).expect("in range");
+                let h = c.corner_floor[idx];
+                assert!(
+                    (h - TEE_FLOOR_HEIGHT).abs() < 1e-9,
+                    "tee corner ({cx},{cy}) should be {TEE_FLOOR_HEIGHT}, got {h}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn bunker_lower_than_fairway() {
+        let c = Course::generate(42);
+        let bunker = c.cell_heights(80, 20).floor[0];
+        let fairway = c.cell_heights(60, 20).floor[0];
+        assert!(
+            bunker < fairway,
+            "bunker floor {bunker} should be lower than fairway {fairway}"
+        );
+    }
+
+    #[test]
+    fn borders_are_solid() {
+        let c = Course::generate(42);
+        assert!(c.is_solid(0, 10));
+        assert!(c.is_solid(199, 10));
+        assert!(c.is_solid(50, 0));
+        assert!(c.is_solid(50, 39));
+    }
+
+    #[test]
+    fn water_is_solid() {
+        let c = Course::generate(42);
+        assert!(c.is_solid(107, 19));
+    }
+
+    #[test]
+    fn fairway_not_solid() {
+        let c = Course::generate(42);
+        assert!(!c.is_solid(60, 20));
+    }
+
+    #[test]
+    fn tee_not_solid() {
+        let c = Course::generate(42);
+        assert!(!c.is_solid(5, 20));
+    }
+
+    #[test]
+    fn green_not_solid() {
+        let c = Course::generate(42);
+        assert!(!c.is_solid(185, 20));
+    }
+
+    #[test]
+    fn out_of_bounds_is_solid() {
+        let c = Course::generate(42);
+        assert!(c.is_solid(-1, 10));
+        assert!(c.is_solid(10, -1));
+        assert!(c.is_solid(200, 10));
+        assert!(c.is_solid(10, 40));
+    }
+
+    #[test]
+    fn ceil_tracks_floor_with_offset() {
+        let c = Course::generate(42);
+        for i in 0..c.corner_floor.len() {
+            let d = c.corner_ceil[i] - c.corner_floor[i];
+            assert!(
+                (d - CEILING_OFFSET).abs() < 1e-9,
+                "ceil - floor should be {CEILING_OFFSET}, got {d}"
+            );
+        }
+    }
+
+    #[test]
+    fn tee_spawn_matches_rooftop() {
+        let c = Course::generate(42);
+        let (x, y, z) = c.tee_spawn();
+        assert!((x - 5.0).abs() < 1e-9);
+        assert!((y - 20.0).abs() < 1e-9);
+        assert!((z - (TEE_FLOOR_HEIGHT + EYE_HEIGHT)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn pin_is_on_green() {
+        let c = Course::generate(42);
+        let (px, py) = c.pin();
+        assert_eq!(c.tile_at(px as i32, py as i32), Some(TILE_GREEN));
+    }
+}

--- a/src/course.rs
+++ b/src/course.rs
@@ -24,7 +24,9 @@ pub const TILE_ROUGH: TileType = 5;
 pub const TILE_BUNKER: TileType = 6;
 /// グリーン。ホールを最低点とする椀。
 pub const TILE_GREEN: TileType = 7;
-/// ウォーターハザード。Phase 1 では solid 扱い。
+/// ウォーターハザード。`is_solid=true` のためボールは物理的に入れない。
+/// floor 値の `-0.2m` は水面描画用の視覚表現で、Phase 2 でウォーターハザード
+/// 判定（1 打罰）として機能させる予定。
 pub const TILE_WATER: TileType = 8;
 
 const MAP_W: usize = 200;
@@ -32,18 +34,19 @@ const MAP_H: usize = 40;
 const CORNER_W: usize = MAP_W + 1;
 const CORNER_H: usize = MAP_H + 1;
 
-const TEE_X: std::ops::RangeInclusive<i32> = 3..=6;
-const TEE_Y: std::ops::RangeInclusive<i32> = 18..=21;
-const FAIRWAY_X: std::ops::RangeInclusive<i32> = 10..=179;
-const FAIRWAY_Y: std::ops::RangeInclusive<i32> = 15..=24;
-const BUNKER1_X: std::ops::RangeInclusive<i32> = 80..=83;
-const BUNKER1_Y: std::ops::RangeInclusive<i32> = 19..=21;
-const BUNKER2_X: std::ops::RangeInclusive<i32> = 140..=142;
-const BUNKER2_Y: std::ops::RangeInclusive<i32> = 17..=20;
-const WATER_X: std::ops::RangeInclusive<i32> = 105..=109;
-const WATER_Y: std::ops::RangeInclusive<i32> = 17..=21;
-const GREEN_X: std::ops::RangeInclusive<i32> = 180..=194;
-const GREEN_Y: std::ops::RangeInclusive<i32> = 16..=23;
+/// タイル範囲は `(start, end_inclusive)` のタプル。`a..=b` へ展開して使う。
+const TEE_X: (i32, i32) = (3, 6);
+const TEE_Y: (i32, i32) = (18, 21);
+const FAIRWAY_X: (i32, i32) = (10, 179);
+const FAIRWAY_Y: (i32, i32) = (15, 24);
+const BUNKER1_X: (i32, i32) = (80, 83);
+const BUNKER1_Y: (i32, i32) = (19, 21);
+const BUNKER2_X: (i32, i32) = (140, 142);
+const BUNKER2_Y: (i32, i32) = (17, 20);
+const WATER_X: (i32, i32) = (105, 109);
+const WATER_Y: (i32, i32) = (17, 21);
+const GREEN_X: (i32, i32) = (180, 194);
+const GREEN_Y: (i32, i32) = (16, 23);
 
 const TEE_FLOOR_HEIGHT: f64 = 20.0;
 const CEILING_OFFSET: f64 = 3.0;
@@ -52,6 +55,14 @@ const PIN_Y: f64 = 20.5;
 const EYE_HEIGHT: f64 = 0.5;
 
 /// Phase 1 の合成コース。
+///
+/// # グリーンの最低点について
+///
+/// グリーンのコーナー高さは `base_height * 0.3 - 0.3 * exp(-d² / 6)` で、
+/// ピン位置 `(190.5, 20.5)` が椀の中心になるように設計しているが、
+/// `base_height` 側の勾配が残るため、**厳密な最低点は seed により ±0.1m 程度
+/// ピンからずれる**可能性がある。Phase 2 のカップ判定は高さではなく位置距離で
+/// 行う想定なので、この微小ずれは問題にならない。
 pub struct Course {
     seed: u64,
     tiles: Vec<TileType>,
@@ -84,7 +95,11 @@ impl Course {
         self.seed
     }
 
-    /// ピン（ホール）の (x, y) ワールド座標。タイル中心。
+    /// ピン（ホール）の `(x, y)` ワールド座標。
+    ///
+    /// 返り値は世界座標系（1 タイル = 1m）。タイル `(x_int, y_int)` の中心は
+    /// `(x_int + 0.5, y_int + 0.5)` なので、ピンはタイル `(190, 20)` の中心
+    /// `(190.5, 20.5)` に置かれている。
     pub fn pin(&self) -> (f64, f64) {
         (PIN_X, PIN_Y)
     }
@@ -116,27 +131,22 @@ fn build_tiles() -> Vec<TileType> {
         tiles[y * MAP_W + (MAP_W - 1)] = TILE_WALL;
     }
     // フェアウェイ帯
-    paint_rect(&mut tiles, &FAIRWAY_X, &FAIRWAY_Y, TILE_FAIRWAY);
+    paint_rect(&mut tiles, FAIRWAY_X, FAIRWAY_Y, TILE_FAIRWAY);
     // バンカー
-    paint_rect(&mut tiles, &BUNKER1_X, &BUNKER1_Y, TILE_BUNKER);
-    paint_rect(&mut tiles, &BUNKER2_X, &BUNKER2_Y, TILE_BUNKER);
+    paint_rect(&mut tiles, BUNKER1_X, BUNKER1_Y, TILE_BUNKER);
+    paint_rect(&mut tiles, BUNKER2_X, BUNKER2_Y, TILE_BUNKER);
     // ウォーター
-    paint_rect(&mut tiles, &WATER_X, &WATER_Y, TILE_WATER);
+    paint_rect(&mut tiles, WATER_X, WATER_Y, TILE_WATER);
     // グリーン
-    paint_rect(&mut tiles, &GREEN_X, &GREEN_Y, TILE_GREEN);
+    paint_rect(&mut tiles, GREEN_X, GREEN_Y, TILE_GREEN);
     // ティー（フェアウェイより外側、最後に塗って優先）
-    paint_rect(&mut tiles, &TEE_X, &TEE_Y, TILE_TEE);
+    paint_rect(&mut tiles, TEE_X, TEE_Y, TILE_TEE);
     tiles
 }
 
-fn paint_rect(
-    tiles: &mut [TileType],
-    xs: &std::ops::RangeInclusive<i32>,
-    ys: &std::ops::RangeInclusive<i32>,
-    tile: TileType,
-) {
-    for y in ys.clone() {
-        for x in xs.clone() {
+fn paint_rect(tiles: &mut [TileType], xs: (i32, i32), ys: (i32, i32), tile: TileType) {
+    for y in ys.0..=ys.1 {
+        for x in xs.0..=xs.1 {
             if x < 0 || y < 0 || (x as usize) >= MAP_W || (y as usize) >= MAP_H {
                 continue;
             }
@@ -167,7 +177,7 @@ fn tile_priority(tile: TileType) -> u32 {
 }
 
 /// コーナー `(cx, cy)` を代表するタイル種。NW/NE/SW/SE の 4 セルから
-/// 優先度最大のものを返す。
+/// 優先度最大のものを返す。全隣接セルが範囲外の場合のみ [`TILE_WALL`] を返す。
 fn corner_tile(tiles: &[TileType], cx: i32, cy: i32) -> TileType {
     let candidates = [
         tile_of(tiles, cx - 1, cy - 1),
@@ -175,18 +185,14 @@ fn corner_tile(tiles: &[TileType], cx: i32, cy: i32) -> TileType {
         tile_of(tiles, cx - 1, cy),
         tile_of(tiles, cx, cy),
     ];
-    let mut best = TILE_WALL;
-    let mut best_prio = 0u32;
-    let mut any = false;
+    let mut best: Option<(TileType, u32)> = None;
     for c in candidates.into_iter().flatten() {
         let p = tile_priority(c);
-        if !any || p > best_prio {
-            best = c;
-            best_prio = p;
-            any = true;
+        if best.is_none_or(|(_, bp)| p > bp) {
+            best = Some((c, p));
         }
     }
-    if any { best } else { TILE_WALL }
+    best.map(|(t, _)| t).unwrap_or(TILE_WALL)
 }
 
 fn base_height(cx: f64, cy: f64, phase_x: f64, phase_y: f64, amp_scale: f64) -> f64 {
@@ -311,9 +317,10 @@ mod tests {
     #[test]
     fn tee_corners_are_flat_twenty() {
         let c = Course::generate(42);
-        // ティー矩形は x=3..=6, y=18..=21。タイル中心でも、タイル内部コーナー
-        // (x=4..=6, y=19..=21) でも高さ 20.0 のはず。優先順位ルールが効いて
-        // いれば境界コーナー (x=3, y=18 等) もティー扱いで 20.0 になる。
+        // ティー矩形は x=3..=6, y=18..=21。タイルコーナー (cx, cy) で、
+        // タイル内部コーナー (x=4..=6, y=19..=21) でも高さ 20.0 のはず。
+        // 優先順位ルールが効いていれば境界コーナー (x=3, y=18 等) もティー
+        // 扱いで 20.0 になる。
         for cy in 18..=22 {
             for cx in 3..=7 {
                 let idx = corner_index(cx, cy).expect("in range");
@@ -405,5 +412,69 @@ mod tests {
         let c = Course::generate(42);
         let (px, py) = c.pin();
         assert_eq!(c.tile_at(px as i32, py as i32), Some(TILE_GREEN));
+    }
+
+    #[test]
+    fn green_west_edge_has_green_priority() {
+        // グリーンは x=180..=194, y=16..=23。コーナー (180, 20) の 4 近傍は
+        // (179,19)=FAIRWAY, (180,19)=GREEN, (179,20)=FAIRWAY, (180,20)=GREEN。
+        // GREEN priority(60) > FAIRWAY priority(50) なのでコーナーは GREEN 式で
+        // 計算される。期待値は `base_height * 0.3 - 0.3 * exp(-d²/6)`。
+        let c = Course::generate(42);
+        let idx = corner_index(180, 20).expect("in range");
+        let actual = c.corner_floor[idx];
+
+        // 同じ seed の位相を再現して GREEN 式を評価。
+        let mut rng = StdRng::seed_from_u64(42);
+        let phase_x: f64 = rng.random_range(0.0..std::f64::consts::TAU);
+        let phase_y: f64 = rng.random_range(0.0..std::f64::consts::TAU);
+        let amp_scale: f64 = rng.random_range(0.8..1.2);
+        let fx = 180.0_f64;
+        let fy = 20.0_f64;
+        let dx = fx - PIN_X;
+        let dy = fy - PIN_Y;
+        let d2 = dx * dx + dy * dy;
+        let expected =
+            base_height(fx, fy, phase_x, phase_y, amp_scale) * 0.3 - 0.3 * (-d2 / 6.0_f64).exp();
+
+        assert!(
+            (actual - expected).abs() < 1e-9,
+            "green corner (180,20) should follow GREEN formula, got {actual}, expected {expected}"
+        );
+
+        // さらに FAIRWAY 式（`base_height` そのまま）とは一致しない（priority が効いている証拠）。
+        let fairway_value = base_height(fx, fy, phase_x, phase_y, amp_scale);
+        assert!(
+            (actual - fairway_value).abs() > 1e-6,
+            "green corner should NOT equal fairway formula"
+        );
+    }
+
+    #[test]
+    fn bunker_corner_priority_over_fairway() {
+        // Bunker1 は x=80..=83, y=19..=21。コーナー (80, 20) の 4 近傍は
+        // (79,19)=FAIRWAY, (80,19)=BUNKER, (79,20)=FAIRWAY, (80,20)=BUNKER。
+        // BUNKER priority(80) > FAIRWAY priority(50) なのでバンカー式が適用され、
+        // floor = base_height - 1.5。
+        let c = Course::generate(42);
+        let idx = corner_index(80, 20).expect("in range");
+        let actual = c.corner_floor[idx];
+
+        let mut rng = StdRng::seed_from_u64(42);
+        let phase_x: f64 = rng.random_range(0.0..std::f64::consts::TAU);
+        let phase_y: f64 = rng.random_range(0.0..std::f64::consts::TAU);
+        let amp_scale: f64 = rng.random_range(0.8..1.2);
+        let fairway_normal = base_height(80.0, 20.0, phase_x, phase_y, amp_scale);
+        let expected_bunker = fairway_normal - 1.5;
+
+        assert!(
+            (actual - expected_bunker).abs() < 1e-9,
+            "bunker corner (80,20) should be base_height - 1.5, got {actual}, expected {expected_bunker}"
+        );
+        // フェアウェイより 1.5m 近く低いはず。
+        assert!(
+            actual < fairway_normal - 1.0,
+            "bunker floor {actual} should be clearly lower than fairway {fairway_normal}"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,11 @@
 //! street-golf — TUI street golf game powered by termray and rapier3d.
 //!
-//! Phase 0 skeleton: this crate currently only exposes a placeholder. Later
-//! phases will add the course builder (`course`), ball physics (`physics`),
-//! shot input (`shot`), and heads-up display (`hud`). The binary entry point
-//! lives in `src/main.rs` and deliberately avoids pulling in higher-level APIs
-//! until they exist.
+//! Phase 1 ではコース定義（[`course`]）を導入する。ティー・フェアウェイ・
+//! バンカー・ウォーターハザード・グリーン・ピンをレイアウトした 200m × 40m の
+//! 合成コースを [`termray::TileMap`] / [`termray::HeightMap`] として公開し、
+//! `cargo run --example fly_through` で歩き回れる。以降のフェーズでは
+//! ボール物理（`physics`）、ショット入力（`shot`）、HUD（`hud`）を追加予定。
+
+pub mod course;
+
+pub use course::{Course, TILE_BUNKER, TILE_FAIRWAY, TILE_GREEN, TILE_ROUGH, TILE_TEE, TILE_WATER};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@
 //! `cargo run --example fly_through` で歩き回れる。以降のフェーズでは
 //! ボール物理（`physics`）、ショット入力（`shot`）、HUD（`hud`）を追加予定。
 
+pub mod collide;
 pub mod course;
 
+pub use collide::{step_x, step_y};
 pub use course::{Course, TILE_BUNKER, TILE_FAIRWAY, TILE_GREEN, TILE_ROUGH, TILE_TEE, TILE_WATER};
+pub use termray::{TILE_EMPTY, TILE_VOID, TILE_WALL};


### PR DESCRIPTION
## 関連 Issue

closes #2

## 変更内容

termray 0.3 の傾斜床を使った手書きコース（200×40 tile、1 tile=1m）とウォークスルー用 example を追加。

### `src/course.rs`（新規 409 行）
- `Course` 構造体: `termray::{TileMap, HeightMap}` 両実装
- タイル ID: `TILE_TEE=3`, `TILE_FAIRWAY=4`, `TILE_ROUGH=5`, `TILE_BUNKER=6`, `TILE_GREEN=7`, `TILE_WATER=8`
- コース構成:
  - ティーグラウンド: `x=3..=6, y=18..=21`、+20m 平坦
  - フェアウェイ: `x=10..=179, y=15..=24`、seed ベース起伏 ±0.4m
  - ラフ: フェアウェイの外側
  - バンカー×2: `x=80..=83/y=19..=21`, `x=140..=142/y=17..=20`、-1.5m 窪み
  - ウォーターハザード: `x=105..=109, y=17..=21`（`is_solid=true`）
  - グリーン: `x=180..=194, y=16..=23`、ホール (190.5, 20.5) を最低点とする椀
- Corner 高さ: 4 近傍セルの最高優先度ルール（`WALL > TEE > BUNKER > WATER > GREEN > FAIRWAY > ROUGH`）でティー 4×4 を完全平坦に保つ
- `rand::rngs::StdRng::seed_from_u64(seed)` による再現性
- `Course::tee_spawn() → (5.0, 20.0, 20.5)`, `Course::pin() → (190.5, 20.5)` を公開（Phase 2 物理で利用）

### `examples/fly_through.rs`（新規 323 行）
- termray の `slope.rs` を雛形に、`CourseScene` で street-golf 色に差し替え
- 初期カメラ: ティー中心 (4.0, 20.0, 20.5)、yaw=0（east 向き）
- `max_distance = 60.0`、ピンスプライト（赤、高さ 2m、`height_scale=2.0`）
- ステータス行に足元タイル名表示

### テスト（13 件全 pass）
- 決定性（same seed → 同一 corner_floor）
- ティー平坦 20m、バンカー窪み、solid 判定、OOB、ceil オフセット、pin/green 整合

### ドキュメント
- \`CLAUDE.md\`: Current phase を Phase 1 に更新
- \`docs/architecture.md\`: マップレイアウト表・corner priority・is_solid 契約を追記
- \`CHANGELOG.md\`: Unreleased に Phase 1 項目

## 完了条件

- [x] \`render_walls\` / \`render_floor_ceiling\` で起伏のある地形が描画される
- [x] ティー地点に立つと遠方にグリーン+ピン（スプライト）が見える（fly_through example で視覚確認）
- [x] コース全体を歩き回って視覚確認できる
- [x] \`cargo fmt --check\` / \`cargo clippy -- -D warnings\` / \`cargo test\` / \`cargo build --release\` 全 pass

## 将来方針（Phase 5+）

最終ゴールは **金沢城＋兼六園を架空のゴルフ場化**。場所のみ固定で、地形は **公開フリーマップ（OSM）+ 高低差データ（SRTM 等）をそのまま取り込んで実地形を再現**する（手書きではない）。スタート/ホール位置も固定。Phase 1 の合成コースはその実データパイプラインに繋ぐ前のサンプル段階。