### PR TITLE
Phase 2: rapier3d ボール物理 + 3人称追従カメラ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to street-golf are documented in this file. The format is ba
 ## [Unreleased]
 
 ### Added
+- Phase 2 rapier3d ball physics + follow camera
+  ([#3](https://github.com/kako-jun/street-golf/issues/3)).
+  `src/physics.rs` wraps a rapier3d 0.32 world with per-tile-type TriMesh
+  colliders generated from `Course::cell_heights` using the
+  `(NW,NE,SE)+(NW,SE,SW)` triangulation that matches termray's floor renderer,
+  plus vertical cuboid colliders on wall cells. The ball is a 46 g dynamic body
+  of radius 2.1 cm with CCD. `Physics::step` runs fixed 60Hz steps via an
+  accumulator so render rate stays independent. `src/camera_follow.rs` adds
+  `FollowCam` with the third-person `ShotStanding` mode (Flying / FirstPerson
+  fall through until Phase 3). `examples/shot_test.rs` fires a hardcoded
+  `(12, 0, 4) m/s` launch at 0.5s and visualises the flight-to-rest sequence.
 - Phase 1 synthetic course ([#2](https://github.com/kako-jun/street-golf/issues/2)).
   `src/course.rs` introduces `Course`, which implements both `termray::TileMap`
   and `termray::HeightMap` for a hand-drawn 200m × 40m layout (rooftop tee,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ cargo fmt --all
 
 ## Current phase
 
-Phase 1 — synthetic course. `cargo run --release --example fly_through` opens a 200m × 40m hand-drawn course (tee / fairway / rough / two bunkers / water hazard / green + pin) on top of termray 0.3's sloped-floor rendering. `Course::generate(42)` is seed-deterministic; the walkthrough lets you verify the terrain before ball physics land in Phase 2. `src/main.rs` still runs the Phase 0 splash — it stays untouched until Phase 2 wires rapier3d in.
+Phase 2 — rapier3d ball physics wired in. `Physics` (`src/physics.rs`) builds per-tile-type TriMesh colliders from `Course::cell_heights` using termray's `(NW,NE,SE)+(NW,SE,SW)` triangulation, drops in a 46g ball with CCD enabled, and runs at a fixed 60Hz timestep with an accumulator so render rate stays independent. `FollowCam` (`src/camera_follow.rs`) provides the third-person ShotStanding view (Flying / FirstPerson fall through to the same calculation until Phase 3). `cargo run --release --example shot_test` fires a hardcoded `(12, 0, 4) m/s` impulse and you watch the ball fly, land, roll, and rest. Phase 1's `fly_through` walkthrough is preserved. `src/main.rs` still runs the Phase 0 splash — it stays untouched until Phase 3 wires the real shot loop in.
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 TUI street golf — tee off from a rooftop, land on the street, keep playing until you hole out.
 
-> **Status**: Pre-alpha. Only the skeleton works right now (Phase 0 — see [#1](https://github.com/kako-jun/street-golf/issues/1)). Expect the repo to grow Phase by Phase into a playable TUI golf game.
+> **Status**: Pre-alpha. Phase 2 wires rapier3d ball physics into the termray view. Shot input and scoring still land in later phases.
 
 ## Stack
 
@@ -16,9 +16,11 @@ TUI street golf — tee off from a rooftop, land on the street, keep playing unt
 ```bash
 cargo build --release
 ./target/release/street-golf
+cargo run --release --example fly_through   # Phase 1 walk-through of the synthetic course
+cargo run --release --example shot_test     # Phase 2 hardcoded 1-shot physics demo
 ```
 
-At Phase 0 the binary clears the terminal to a dark meadow green for about 0.8 seconds, then exits — just enough to prove the render pipeline links up. Phase 1 will build a synthetic course and render one playable hole.
+The Phase 0 binary still clears the terminal to a dark meadow green for about 0.8 seconds and exits. The Phase 1 `fly_through` example lets you stroll the 200×40 synthetic course. The Phase 2 `shot_test` example fires a preset shot at 0.5s and lets you watch the ball fly, land, roll, and come to rest under rapier3d, with a third-person ShotStanding follow camera.
 
 ## Roadmap
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,6 +79,21 @@ Phase 1 (#2)  Course heightmap ───┬┘
 - **Phase 4** adds `hud.rs`: score card, club indicator, hole-out detection, round end.
 - **Phase 5+** replaces the synthetic course with real-world data pulled from OpenStreetMap (geometry) and SRTM (elevation).
 
+## Phase 2 — ball physics wired in
+
+`src/physics.rs` turns `Course::cell_heights` into rapier3d 0.32 colliders. Two invariants drive the build:
+
+1. **Triangulation matches termray's floor renderer.** Every cell `(x, y)` is split into `(NW, NE, SE)` + `(NW, SE, SW)` — the same split termray uses when it rasterises the sloped floor. This guarantees the physical surface the ball rolls on is pixel-identical to the surface the camera sees. Corners use termray's `CornerHeights.floor = [NW, NE, SW, SE]` directly.
+2. **Vertical axis is Z.** rapier3d's default is Y-up; street-golf sets gravity to `(0, 0, -9.81)` and constructs all `Vector::new(x, y, z)` with z as height, staying consistent with termray's Z coordinate.
+
+Triangles are grouped by the target tile type (TEE / FAIRWAY / ROUGH / BUNKER / GREEN / WATER / WALL), and each group becomes one `ColliderBuilder::trimesh` fixed collider with its own friction / restitution. Wall cells additionally get a vertical `cuboid(0.5, 0.5, 5.0)` so the ball can't escape through the map border even if it launches high.
+
+The ball is a 46 g dynamic rigid body (radius 2.1 cm) with CCD enabled. `Physics::step(dt)` runs as many fixed 1/60 s physics ticks as `dt` warrants via an accumulator, leaving the render loop free to run at whatever pace the terminal can sustain. At-rest detection is `|linvel| < 0.05 ∧ |angvel| < 0.1` held for 0.5 s.
+
+`FollowCam` (`src/camera_follow.rs`) derives the termray camera pose from the ball state. The MVP mode `ShotStanding` places the camera 5 m behind the ball (along yaw) and 2 m above, with a small downward pitch. `Flying` and `FirstPerson` exist as enum variants for Phase 3+ but currently fall through to `ShotStanding` to avoid `todo!()` panics in example code.
+
+`examples/shot_test.rs` is the Phase 2 end-to-end demo: 0.5 s after launch it applies `set_linvel((12, 0, 4))` and visualises the flight-to-rest trajectory with the ShotStanding camera.
+
 ## Current state (Phase 1)
 
 `src/course.rs` now defines `Course` — a synthetic 1-hole course that implements both `termray::TileMap` and `termray::HeightMap`. `examples/fly_through.rs` drives it as an interactive walkthrough so the terrain can be verified visually before Phase 2 introduces ball physics.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,10 +83,10 @@ Phase 1 (#2)  Course heightmap ───┬┘
 
 `src/physics.rs` turns `Course::cell_heights` into rapier3d 0.32 colliders. Two invariants drive the build:
 
-1. **Triangulation matches termray's floor renderer.** Every cell `(x, y)` is split into `(NW, NE, SE)` + `(NW, SE, SW)` — the same split termray uses when it rasterises the sloped floor. This guarantees the physical surface the ball rolls on is pixel-identical to the surface the camera sees. Corners use termray's `CornerHeights.floor = [NW, NE, SW, SE]` directly.
+1. **Triangulation matches termray's floor renderer.** Every cell `(x, y)` is split into `(NW, NE, SE)` + `(NW, SE, SW)` — the same split termray uses when it rasterises the sloped floor. The `(NW, NE, SE) + (NW, SE, SW)` split matches termray's bilinear surface exactly along the NW→SE diagonal; off-diagonal points deviate by at most the bilinear patch saddle, which is sub-centimetre for Phase 1 terrain (±0.4m amplitude). The deviation is invisible at the ball's 0.021m radius and the 60Hz integration step. Corners use termray's `CornerHeights.floor = [NW, NE, SW, SE]` directly.
 2. **Vertical axis is Z.** rapier3d's default is Y-up; street-golf sets gravity to `(0, 0, -9.81)` and constructs all `Vector::new(x, y, z)` with z as height, staying consistent with termray's Z coordinate.
 
-Triangles are grouped by the target tile type (TEE / FAIRWAY / ROUGH / BUNKER / GREEN / WATER / WALL), and each group becomes one `ColliderBuilder::trimesh` fixed collider with its own friction / restitution. Wall cells additionally get a vertical `cuboid(0.5, 0.5, 5.0)` so the ball can't escape through the map border even if it launches high.
+Triangles are grouped by the target tile type (TEE / FAIRWAY / ROUGH / BUNKER / GREEN / WATER), and each group becomes one `ColliderBuilder::trimesh` fixed collider with its own friction / restitution. Wall cells are handled exclusively by a vertical `cuboid(0.5, 0.5, 5.0)` per cell so the ball can't escape through the map border even if it launches high — their z=0 floor triangles would be unreachable behind the cuboid, so the trimesh build skips `TILE_WALL` entirely.
 
 The ball is a 46 g dynamic rigid body (radius 2.1 cm) with CCD enabled. `Physics::step(dt)` runs as many fixed 1/60 s physics ticks as `dt` warrants via an accumulator, leaving the render loop free to run at whatever pace the terminal can sustain. At-rest detection is `|linvel| < 0.05 ∧ |angvel| < 0.1` held for 0.5 s.
 

--- a/examples/shot_test.rs
+++ b/examples/shot_test.rs
@@ -1,0 +1,278 @@
+//! Phase 2 のショット検証例。
+//!
+//! `cargo run --release --example shot_test` で起動。0.5 秒後にハードコード
+//! された初速 `(12, 0, 4) m/s` をボールに与え、rapier3d の物理で飛翔 →
+//! 着地 → 転動 → 停止するまでを 3 人称追従カメラで観察する。Phase 3 で
+//! キー入力によるショット操作に置き換える予定。
+//!
+//! 操作:
+//! - `esc` — 終了
+//! - 停止後 15 秒経過すると自動終了
+
+use std::io::{Write, stdout};
+use std::time::{Duration, Instant};
+
+use crossterm::cursor::{Hide, MoveTo, Show};
+use crossterm::event::{Event, KeyCode, poll, read};
+use crossterm::execute;
+use crossterm::style::{
+    Color as CtColor, Print, ResetColor, SetBackgroundColor, SetForegroundColor,
+};
+use crossterm::terminal::{
+    Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode,
+    enable_raw_mode, size,
+};
+
+use street_golf::{
+    Course, FollowCam, FollowMode, Physics, TILE_BUNKER, TILE_FAIRWAY, TILE_GREEN, TILE_ROUGH,
+    TILE_TEE, TILE_WATER,
+};
+use termray::{
+    Camera, Color, FloorTexturer, Framebuffer, HitSide, Sprite, SpriteArt, SpriteDef, TILE_WALL,
+    TileType, WallTexturer, project_sprites, render_floor_ceiling, render_sprites, render_walls,
+};
+
+const MAX_DISTANCE: f64 = 80.0;
+const PIN_SPRITE_TYPE: u8 = 1;
+const BALL_SPRITE_TYPE: u8 = 2;
+const LAUNCH_DELAY: f64 = 0.5;
+const POST_REST_TIMEOUT: f64 = 15.0;
+
+struct CourseScene<'a> {
+    course: &'a Course,
+}
+
+impl<'a> WallTexturer for CourseScene<'a> {
+    fn sample_wall(
+        &self,
+        _tile: TileType,
+        _wall_x: f64,
+        _wall_y: f64,
+        side: HitSide,
+        brightness: f64,
+        _tile_hash: u32,
+    ) -> Color {
+        let base = match side {
+            HitSide::Vertical => Color::rgb(160, 140, 100),
+            HitSide::Horizontal => Color::rgb(130, 110, 80),
+        };
+        base.darken(brightness)
+    }
+}
+
+impl<'a> FloorTexturer for CourseScene<'a> {
+    fn sample_floor(&self, wx: f64, wy: f64, brightness: f64) -> Color {
+        let cx = wx.floor() as i32;
+        let cy = wy.floor() as i32;
+        let color = match self.course.tile_at(cx, cy) {
+            Some(TILE_FAIRWAY) => Color::rgb(100, 160, 80),
+            Some(TILE_ROUGH) => Color::rgb(70, 110, 55),
+            Some(TILE_BUNKER) => Color::rgb(220, 200, 150),
+            Some(TILE_GREEN) => Color::rgb(120, 180, 90),
+            Some(TILE_TEE) => Color::rgb(110, 140, 100),
+            Some(TILE_WATER) => Color::rgb(50, 100, 180),
+            Some(TILE_WALL) => Color::rgb(160, 140, 100),
+            _ => Color::rgb(70, 110, 55),
+        };
+        color.darken(brightness)
+    }
+
+    fn sample_ceiling(&self, _wx: f64, _wy: f64, brightness: f64) -> Color {
+        Color::rgb(130, 170, 210).darken(brightness)
+    }
+}
+
+/// ピン（赤い旗竿）とボール（白球）を 1 本の SpriteArt で配信する。
+struct ShotArt {
+    pin: SpriteDef,
+    ball: SpriteDef,
+}
+
+impl ShotArt {
+    fn new() -> Self {
+        const PIN_PATTERN: &[&str] = &[
+            "##.", "##.", "##.", "#..", "#..", "#..", "#..", "#..", "#..", "#..",
+        ];
+        const BALL_PATTERN: &[&str] = &[".#.", "###", ".#."];
+        Self {
+            pin: SpriteDef {
+                pattern: PIN_PATTERN,
+                height_scale: 2.0,
+                float_offset_scale: 0.0,
+            },
+            ball: SpriteDef {
+                pattern: BALL_PATTERN,
+                height_scale: 0.3,
+                float_offset_scale: 1.0,
+            },
+        }
+    }
+}
+
+impl SpriteArt for ShotArt {
+    fn art(&self, sprite_type: u8) -> Option<&SpriteDef> {
+        match sprite_type {
+            PIN_SPRITE_TYPE => Some(&self.pin),
+            BALL_SPRITE_TYPE => Some(&self.ball),
+            _ => None,
+        }
+    }
+
+    fn color(&self, sprite_type: u8) -> Color {
+        match sprite_type {
+            PIN_SPRITE_TYPE => Color::rgb(220, 30, 30),
+            BALL_SPRITE_TYPE => Color::rgb(240, 240, 240),
+            _ => Color::rgb(255, 255, 255),
+        }
+    }
+}
+
+struct TerminalGuard;
+
+impl TerminalGuard {
+    fn new() -> std::io::Result<Self> {
+        enable_raw_mode()?;
+        execute!(stdout(), EnterAlternateScreen, Hide, Clear(ClearType::All))?;
+        Ok(Self)
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        let _ = execute!(stdout(), Show, LeaveAlternateScreen);
+        let _ = disable_raw_mode();
+    }
+}
+
+fn present(fb: &Framebuffer, status: &str) -> std::io::Result<()> {
+    let mut stdout = stdout();
+    execute!(stdout, MoveTo(0, 0))?;
+    for y in (0..fb.height()).step_by(2) {
+        for x in 0..fb.width() {
+            let top = fb.get_pixel(x, y);
+            let bot = fb.get_pixel(x, (y + 1).min(fb.height() - 1));
+            execute!(
+                stdout,
+                SetForegroundColor(CtColor::Rgb {
+                    r: top.r,
+                    g: top.g,
+                    b: top.b
+                }),
+                SetBackgroundColor(CtColor::Rgb {
+                    r: bot.r,
+                    g: bot.g,
+                    b: bot.b
+                }),
+                Print("\u{2580}"),
+            )?;
+        }
+        execute!(stdout, ResetColor, Print("\r\n"))?;
+    }
+    execute!(stdout, ResetColor, Print(status))?;
+    stdout.flush()
+}
+
+fn main() -> std::io::Result<()> {
+    let (cols, rows) = size()?;
+    let fb_w = cols as usize;
+    let fb_h = (rows as usize).saturating_sub(2) * 2;
+    if fb_w == 0 || fb_h == 0 {
+        return Ok(());
+    }
+
+    let course = Course::generate(42);
+    let scene = CourseScene { course: &course };
+    let art = ShotArt::new();
+
+    let (tee_x, tee_y, tee_z) = course.tee_spawn();
+    let (pin_x, pin_y) = course.pin();
+    let ball_spawn = [tee_x + 0.5, tee_y, tee_z - 0.5 + 0.3];
+
+    let mut physics = Physics::new(&course, ball_spawn);
+    let yaw = 0.0;
+    let follow = FollowCam::new(FollowMode::ShotStanding, yaw);
+
+    let mut cam = Camera::with_z(tee_x, tee_y, tee_z, yaw, 70f64.to_radians());
+    let mut fb = Framebuffer::new(fb_w, fb_h);
+
+    let _guard = TerminalGuard::new()?;
+
+    let mut last = Instant::now();
+    let mut elapsed = 0.0_f64;
+    let mut launched = false;
+    let mut rest_timer = 0.0_f64;
+    let mut running = true;
+
+    while running {
+        let now = Instant::now();
+        let dt = (now - last).as_secs_f64().min(0.05);
+        last = now;
+        elapsed += dt;
+
+        while poll(Duration::from_millis(0))? {
+            if let Event::Key(key) = read()?
+                && key.code == KeyCode::Esc
+            {
+                running = false;
+                break;
+            }
+        }
+
+        if !launched && elapsed >= LAUNCH_DELAY {
+            physics.launch([12.0, 0.0, 4.0]);
+            launched = true;
+        }
+
+        physics.step(dt);
+        let state = physics.ball_state();
+        if state.at_rest {
+            rest_timer += dt;
+            if rest_timer >= POST_REST_TIMEOUT {
+                running = false;
+            }
+        } else {
+            rest_timer = 0.0;
+        }
+
+        let (cx, cy, cz, cyaw, cpitch) = follow.update(state.pos);
+        cam.set_pose(cx, cy, cyaw);
+        cam.set_z(cz);
+        cam.set_pitch(cpitch);
+
+        let sprites = vec![
+            Sprite {
+                x: pin_x,
+                y: pin_y,
+                sprite_type: PIN_SPRITE_TYPE,
+            },
+            Sprite {
+                x: state.pos[0],
+                y: state.pos[1],
+                sprite_type: BALL_SPRITE_TYPE,
+            },
+        ];
+
+        fb.clear(Color::default());
+        let rays = cam.cast_all_rays(&course, fb_w, MAX_DISTANCE);
+        render_floor_ceiling(&mut fb, &rays, &scene, &course, &cam, MAX_DISTANCE);
+        render_walls(&mut fb, &rays, &scene, &course, &cam, MAX_DISTANCE);
+        let projected = project_sprites(&sprites, &cam, &course, fb_w, fb_h);
+        render_sprites(&mut fb, &projected, &rays, &art, MAX_DISTANCE);
+
+        let status = format!(
+            "pos=({:5.1},{:5.1},{:5.2}) vel=({:5.1},{:5.1},{:5.1}) rest={} [esc=quit]",
+            state.pos[0],
+            state.pos[1],
+            state.pos[2],
+            state.vel[0],
+            state.vel[1],
+            state.vel[2],
+            state.at_rest
+        );
+        present(&fb, &status)?;
+
+        std::thread::sleep(Duration::from_millis(16));
+    }
+
+    Ok(())
+}

--- a/src/camera_follow.rs
+++ b/src/camera_follow.rs
@@ -1,0 +1,83 @@
+//! 3 人称追従カメラ。
+//!
+//! [`FollowMode::ShotStanding`] はボールの後方 5m・上空 2m から見下ろす
+//! カメラ姿勢を返す。Flying / FirstPerson は Phase 3 以降で実装予定で、
+//! 現状は ShotStanding と同じ計算にフォールバックする。
+//!
+//! 返り値は termray の [`termray::Camera`] に渡せる `(x, y, z, yaw, pitch)`。
+
+/// 追従モード。現状 MVP では ShotStanding のみ実装。
+pub enum FollowMode {
+    ShotStanding,
+    Flying,
+    FirstPerson,
+}
+
+/// 追従カメラの状態。`yaw` はショットの狙い方向。
+pub struct FollowCam {
+    pub mode: FollowMode,
+    pub yaw: f64,
+}
+
+const STANDING_BACK: f64 = 5.0;
+const STANDING_UP: f64 = 2.0;
+const STANDING_PITCH: f64 = -0.15;
+
+impl FollowCam {
+    pub fn new(mode: FollowMode, yaw: f64) -> Self {
+        Self { mode, yaw }
+    }
+
+    /// ボールのワールド座標から `(cam_x, cam_y, cam_z, cam_yaw, cam_pitch)` を返す。
+    pub fn update(&self, ball: [f64; 3]) -> (f64, f64, f64, f64, f64) {
+        match self.mode {
+            FollowMode::ShotStanding | FollowMode::Flying | FollowMode::FirstPerson => {
+                self.shot_standing(ball)
+            }
+        }
+    }
+
+    fn shot_standing(&self, ball: [f64; 3]) -> (f64, f64, f64, f64, f64) {
+        let fx = self.yaw.cos();
+        let fy = self.yaw.sin();
+        let cx = ball[0] - fx * STANDING_BACK;
+        let cy = ball[1] - fy * STANDING_BACK;
+        let cz = ball[2] + STANDING_UP;
+        (cx, cy, cz, self.yaw, STANDING_PITCH)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shot_standing_places_camera_behind_ball() {
+        let cam = FollowCam::new(FollowMode::ShotStanding, 0.0);
+        let (cx, cy, cz, cyaw, cpitch) = cam.update([10.0, 5.0, 1.0]);
+        // yaw=0 は +X 方向を見る。カメラは ball から -X に 5m。
+        assert!((cx - 5.0).abs() < 1e-9);
+        assert!((cy - 5.0).abs() < 1e-9);
+        assert!((cz - 3.0).abs() < 1e-9);
+        assert!((cyaw - 0.0).abs() < 1e-9);
+        assert!((cpitch - (-0.15)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn shot_standing_respects_yaw() {
+        let cam = FollowCam::new(FollowMode::ShotStanding, std::f64::consts::FRAC_PI_2);
+        let (cx, cy, _cz, _cyaw, _cpitch) = cam.update([10.0, 10.0, 1.0]);
+        // yaw=π/2 は +Y 方向を見る。カメラは ball から -Y に 5m。
+        assert!((cx - 10.0).abs() < 1e-6);
+        assert!((cy - 5.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn flying_and_first_person_fall_through_to_standing() {
+        let a = FollowCam::new(FollowMode::Flying, 0.0).update([0.0, 0.0, 0.0]);
+        let b = FollowCam::new(FollowMode::FirstPerson, 0.0).update([0.0, 0.0, 0.0]);
+        let c = FollowCam::new(FollowMode::ShotStanding, 0.0).update([0.0, 0.0, 0.0]);
+        assert_eq!(a, b);
+        assert_eq!(b, c);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,12 @@
 //! `cargo run --example fly_through` で歩き回れる。以降のフェーズでは
 //! ボール物理（`physics`）、ショット入力（`shot`）、HUD（`hud`）を追加予定。
 
+pub mod camera_follow;
 pub mod collide;
 pub mod course;
 pub mod physics;
 
+pub use camera_follow::{FollowCam, FollowMode};
 pub use collide::{step_x, step_y};
 pub use course::{Course, TILE_BUNKER, TILE_FAIRWAY, TILE_GREEN, TILE_ROUGH, TILE_TEE, TILE_WATER};
 pub use physics::{BallState, Physics};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,9 @@
 
 pub mod collide;
 pub mod course;
+pub mod physics;
 
 pub use collide::{step_x, step_y};
 pub use course::{Course, TILE_BUNKER, TILE_FAIRWAY, TILE_GREEN, TILE_ROUGH, TILE_TEE, TILE_WATER};
+pub use physics::{BallState, Physics};
 pub use termray::{TILE_EMPTY, TILE_VOID, TILE_WALL};

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -19,11 +19,15 @@ const MAP_W: i32 = 200;
 const MAP_H: i32 = 40;
 const FIXED_DT: f64 = 1.0 / 60.0;
 const BALL_RADIUS: f64 = 0.021;
+// R&A/USGA 規格: ゴルフボールは 45.93g 以下。46g を丸めて採用。
 const BALL_MASS: f64 = 0.046;
 const AT_REST_LINVEL: f64 = 0.05;
 const AT_REST_ANGVEL: f64 = 0.1;
 const AT_REST_DURATION: f64 = 0.5;
 const WALL_CEILING_HALF: f64 = 5.0;
+/// `step(dt)` で一度に処理する実時間の上限。スリープ・デバッガ停止等で
+/// 巨大な `dt` が来たとき spiral-of-death を防ぐ（最大 15 物理ステップ / 呼び出し）。
+const MAX_ACCUMULATED_DT: f64 = 0.25;
 
 /// ボールの現在状態。f64 API で termray 側と揃える。
 pub struct BallState {
@@ -98,8 +102,15 @@ impl Physics {
     }
 
     /// 実時間 `dt` 秒分ぶん物理を進める。内部では `1/60s` 固定ステップで回す。
+    ///
+    /// 蓄積した実時間は [`MAX_ACCUMULATED_DT`] でクランプする。スリープ・
+    /// デバッガ停止などで巨大な `dt` が入ってきても、アキュムレータの while
+    /// ループが CPU を焼き切る spiral-of-death を起こさない。
     pub fn step(&mut self, dt: f64) {
         self.time_accumulator += dt;
+        if self.time_accumulator > MAX_ACCUMULATED_DT {
+            self.time_accumulator = MAX_ACCUMULATED_DT;
+        }
         while self.time_accumulator >= FIXED_DT {
             self.physics_pipeline.step(
                 self.gravity,
@@ -145,13 +156,16 @@ impl Physics {
         }
     }
 
-    /// ボールにショット速度を与える（`linvel` を直接置換）。
-    /// `impulse` 名だが、質量を跨がず速度をそのままセットするので呼び出し側は
-    /// 「初速 m/s」を渡せばよい。停止タイマーもリセットする。
-    pub fn launch(&mut self, impulse: [f64; 3]) {
+    /// ボールにショット初速を与える。線形速度を m/s で直接セットし、
+    /// impulse = J·s のような質量を跨ぐ計算はしない。停止タイマーもリセットする。
+    pub fn launch(&mut self, velocity_mps: [f64; 3]) {
         let body = &mut self.bodies[self.ball_handle];
         body.set_linvel(
-            Vector::new(impulse[0] as f32, impulse[1] as f32, impulse[2] as f32),
+            Vector::new(
+                velocity_mps[0] as f32,
+                velocity_mps[1] as f32,
+                velocity_mps[2] as f32,
+            ),
             true,
         );
         self.at_rest_timer = 0.0;
@@ -166,6 +180,8 @@ fn tile_material(tile: TileType) -> (f32, f32) {
         TILE_ROUGH => (0.5, 0.2),
         TILE_BUNKER => (0.9, 0.05),
         TILE_GREEN => (0.1, 0.1),
+        // TODO: Phase 3+ でウォーターハザード判定を追加（1打罰 + リプレース）。
+        // 現状 Phase 2 では物理的に solid として衝突するだけ。
         TILE_WATER => (0.2, 0.3),
         TILE_WALL => (0.4, 0.3),
         _ => (0.4, 0.2),
@@ -186,16 +202,16 @@ fn cell_triangles(course: &Course, x: i32, y: i32) -> [[Vector; 3]; 2] {
 }
 
 /// 地形 TriMesh コライダをタイル種ごとにグループ化して一括生成する。
-/// 追加で各 `TILE_WALL` セルには垂直 cuboid を置き、ボールの水平脱出を防ぐ。
+/// `TILE_WALL` は trimesh には含めず、垂直 cuboid で独立に扱う。
+/// （壁セルの z=0 床三角形は垂直 cuboid の陰に隠れて到達不能なため冗長）。
 fn build_terrain_colliders(course: &Course, colliders: &mut ColliderSet) {
-    let tile_types: [TileType; 7] = [
+    let tile_types: [TileType; 6] = [
         TILE_TEE,
         TILE_FAIRWAY,
         TILE_ROUGH,
         TILE_BUNKER,
         TILE_GREEN,
         TILE_WATER,
-        TILE_WALL,
     ];
 
     for &target in &tile_types {
@@ -310,6 +326,23 @@ mod tests {
         assert!((tris[1][0].z as f64 - h.floor[0]).abs() < 1e-6);
         assert!((tris[1][1].z as f64 - h.floor[3]).abs() < 1e-6);
         assert!((tris[1][2].z as f64 - h.floor[2]).abs() < 1e-6);
+    }
+
+    #[test]
+    fn huge_dt_is_clamped_not_spiraling() {
+        // `step(10.0)` は最大 15 ステップ相当にクランプされるはず。
+        // panic しない & アキュムレータの残余が FIXED_DT 未満であることを確認。
+        let course = Course::generate(42);
+        let mut phys = Physics::new(&course, [5.0, 20.0, 25.0]);
+        let t0 = std::time::Instant::now();
+        phys.step(10.0);
+        let elapsed = t0.elapsed();
+        assert!(
+            elapsed.as_secs_f64() < 1.0,
+            "step(10.0) should clamp and return quickly, took {:?}",
+            elapsed
+        );
+        assert!(phys.time_accumulator < FIXED_DT);
     }
 
     #[test]

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -1,0 +1,324 @@
+//! Phase 2 のボール物理。
+//!
+//! [`Course`] の `CornerHeights` から per-tile-type な TriMesh コライダを
+//! 生成し、rapier3d の dynamic rigid body でゴルフボールをシミュレーションする。
+//! 三角分割は termray の床描画と同じ `(NW, NE, SE) + (NW, SE, SW)` 分割。
+//! 垂直軸は Z で、重力は `(0, 0, -9.81)`。
+//!
+//! 固定タイムステップ 60Hz のアキュムレータで [`Physics::step`] を呼ぶと
+//! 実時間経過分だけ `1/60s` ステップを回す。レンダ側のフレームレートと独立。
+
+use rapier3d::prelude::*;
+
+use crate::course::{
+    Course, TILE_BUNKER, TILE_FAIRWAY, TILE_GREEN, TILE_ROUGH, TILE_TEE, TILE_WATER,
+};
+use termray::{HeightMap, TILE_WALL, TileType};
+
+const MAP_W: i32 = 200;
+const MAP_H: i32 = 40;
+const FIXED_DT: f64 = 1.0 / 60.0;
+const BALL_RADIUS: f64 = 0.021;
+const BALL_MASS: f64 = 0.046;
+const AT_REST_LINVEL: f64 = 0.05;
+const AT_REST_ANGVEL: f64 = 0.1;
+const AT_REST_DURATION: f64 = 0.5;
+const WALL_CEILING_HALF: f64 = 5.0;
+
+/// ボールの現在状態。f64 API で termray 側と揃える。
+pub struct BallState {
+    pub pos: [f64; 3],
+    pub vel: [f64; 3],
+    pub at_rest: bool,
+}
+
+/// rapier3d の世界を包み込む Phase 2 の物理エンジン。
+pub struct Physics {
+    gravity: Vector,
+    integration_parameters: IntegrationParameters,
+    physics_pipeline: PhysicsPipeline,
+    island_manager: IslandManager,
+    broad_phase: DefaultBroadPhase,
+    narrow_phase: NarrowPhase,
+    impulse_joints: ImpulseJointSet,
+    multibody_joints: MultibodyJointSet,
+    ccd_solver: CCDSolver,
+    bodies: RigidBodySet,
+    colliders: ColliderSet,
+    ball_handle: RigidBodyHandle,
+    at_rest_timer: f64,
+    time_accumulator: f64,
+}
+
+impl Physics {
+    /// コースと初期スポーン位置からワールドを組み立てる。
+    pub fn new(course: &Course, ball_spawn: [f64; 3]) -> Self {
+        let mut bodies = RigidBodySet::new();
+        let mut colliders = ColliderSet::new();
+
+        build_terrain_colliders(course, &mut colliders);
+
+        let ball_body = RigidBodyBuilder::dynamic()
+            .translation(Vector::new(
+                ball_spawn[0] as f32,
+                ball_spawn[1] as f32,
+                ball_spawn[2] as f32,
+            ))
+            .ccd_enabled(true)
+            .build();
+        let ball_handle = bodies.insert(ball_body);
+        let ball_collider = ColliderBuilder::ball(BALL_RADIUS as f32)
+            .mass(BALL_MASS as f32)
+            .friction(0.3)
+            .restitution(0.35)
+            .build();
+        colliders.insert_with_parent(ball_collider, ball_handle, &mut bodies);
+
+        let integration_parameters = IntegrationParameters {
+            dt: FIXED_DT as f32,
+            ..IntegrationParameters::default()
+        };
+
+        Self {
+            gravity: Vector::new(0.0, 0.0, -9.81),
+            integration_parameters,
+            physics_pipeline: PhysicsPipeline::new(),
+            island_manager: IslandManager::new(),
+            broad_phase: DefaultBroadPhase::new(),
+            narrow_phase: NarrowPhase::new(),
+            impulse_joints: ImpulseJointSet::new(),
+            multibody_joints: MultibodyJointSet::new(),
+            ccd_solver: CCDSolver::new(),
+            bodies,
+            colliders,
+            ball_handle,
+            at_rest_timer: 0.0,
+            time_accumulator: 0.0,
+        }
+    }
+
+    /// 実時間 `dt` 秒分ぶん物理を進める。内部では `1/60s` 固定ステップで回す。
+    pub fn step(&mut self, dt: f64) {
+        self.time_accumulator += dt;
+        while self.time_accumulator >= FIXED_DT {
+            self.physics_pipeline.step(
+                self.gravity,
+                &self.integration_parameters,
+                &mut self.island_manager,
+                &mut self.broad_phase,
+                &mut self.narrow_phase,
+                &mut self.bodies,
+                &mut self.colliders,
+                &mut self.impulse_joints,
+                &mut self.multibody_joints,
+                &mut self.ccd_solver,
+                &(),
+                &(),
+            );
+            self.update_at_rest(FIXED_DT);
+            self.time_accumulator -= FIXED_DT;
+        }
+    }
+
+    fn update_at_rest(&mut self, dt: f64) {
+        let body = &self.bodies[self.ball_handle];
+        let lv = body.linvel();
+        let av = body.angvel();
+        let lin_mag = (lv.x * lv.x + lv.y * lv.y + lv.z * lv.z).sqrt() as f64;
+        let ang_mag = (av.x * av.x + av.y * av.y + av.z * av.z).sqrt() as f64;
+        if lin_mag < AT_REST_LINVEL && ang_mag < AT_REST_ANGVEL {
+            self.at_rest_timer += dt;
+        } else {
+            self.at_rest_timer = 0.0;
+        }
+    }
+
+    /// ボールの現在状態（位置・速度・停止判定）を返す。
+    pub fn ball_state(&self) -> BallState {
+        let body = &self.bodies[self.ball_handle];
+        let t = body.translation();
+        let v = body.linvel();
+        BallState {
+            pos: [t.x as f64, t.y as f64, t.z as f64],
+            vel: [v.x as f64, v.y as f64, v.z as f64],
+            at_rest: self.at_rest_timer >= AT_REST_DURATION,
+        }
+    }
+
+    /// ボールにショット速度を与える（`linvel` を直接置換）。
+    /// `impulse` 名だが、質量を跨がず速度をそのままセットするので呼び出し側は
+    /// 「初速 m/s」を渡せばよい。停止タイマーもリセットする。
+    pub fn launch(&mut self, impulse: [f64; 3]) {
+        let body = &mut self.bodies[self.ball_handle];
+        body.set_linvel(
+            Vector::new(impulse[0] as f32, impulse[1] as f32, impulse[2] as f32),
+            true,
+        );
+        self.at_rest_timer = 0.0;
+    }
+}
+
+/// タイル種ごとの (friction, restitution) ペア。
+fn tile_material(tile: TileType) -> (f32, f32) {
+    match tile {
+        TILE_TEE => (0.3, 0.15),
+        TILE_FAIRWAY => (0.3, 0.2),
+        TILE_ROUGH => (0.5, 0.2),
+        TILE_BUNKER => (0.9, 0.05),
+        TILE_GREEN => (0.1, 0.1),
+        TILE_WATER => (0.2, 0.3),
+        TILE_WALL => (0.4, 0.3),
+        _ => (0.4, 0.2),
+    }
+}
+
+/// セル `(x, y)` の NW/NE/SE/SW 4 頂点を `(NW, NE, SE) + (NW, SE, SW)` に分割して返す。
+fn cell_triangles(course: &Course, x: i32, y: i32) -> [[Vector; 3]; 2] {
+    let h = course.cell_heights(x, y);
+    let fx = x as f32;
+    let fy = y as f32;
+    // CornerHeights.floor indexing: [NW, NE, SW, SE]
+    let nw = Vector::new(fx, fy, h.floor[0] as f32);
+    let ne = Vector::new(fx + 1.0, fy, h.floor[1] as f32);
+    let sw = Vector::new(fx, fy + 1.0, h.floor[2] as f32);
+    let se = Vector::new(fx + 1.0, fy + 1.0, h.floor[3] as f32);
+    [[nw, ne, se], [nw, se, sw]]
+}
+
+/// 地形 TriMesh コライダをタイル種ごとにグループ化して一括生成する。
+/// 追加で各 `TILE_WALL` セルには垂直 cuboid を置き、ボールの水平脱出を防ぐ。
+fn build_terrain_colliders(course: &Course, colliders: &mut ColliderSet) {
+    let tile_types: [TileType; 7] = [
+        TILE_TEE,
+        TILE_FAIRWAY,
+        TILE_ROUGH,
+        TILE_BUNKER,
+        TILE_GREEN,
+        TILE_WATER,
+        TILE_WALL,
+    ];
+
+    for &target in &tile_types {
+        let mut vertices: Vec<Vector> = Vec::new();
+        let mut indices: Vec<[u32; 3]> = Vec::new();
+        for y in 0..MAP_H {
+            for x in 0..MAP_W {
+                if course.tile_at(x, y) != Some(target) {
+                    continue;
+                }
+                let tris = cell_triangles(course, x, y);
+                for tri in tris {
+                    let base = vertices.len() as u32;
+                    vertices.push(tri[0]);
+                    vertices.push(tri[1]);
+                    vertices.push(tri[2]);
+                    indices.push([base, base + 1, base + 2]);
+                }
+            }
+        }
+        if indices.is_empty() {
+            continue;
+        }
+        let (friction, restitution) = tile_material(target);
+        let collider = ColliderBuilder::trimesh(vertices, indices)
+            .expect("trimesh build")
+            .friction(friction)
+            .restitution(restitution)
+            .build();
+        colliders.insert(collider);
+    }
+
+    // 壁セルに垂直 cuboid を足してボールの水平脱出を防ぐ。
+    let (wall_friction, wall_restitution) = tile_material(TILE_WALL);
+    for y in 0..MAP_H {
+        for x in 0..MAP_W {
+            if course.tile_at(x, y) != Some(TILE_WALL) {
+                continue;
+            }
+            let collider = ColliderBuilder::cuboid(0.5, 0.5, WALL_CEILING_HALF as f32)
+                .translation(Vector::new(
+                    x as f32 + 0.5,
+                    y as f32 + 0.5,
+                    WALL_CEILING_HALF as f32,
+                ))
+                .friction(wall_friction)
+                .restitution(wall_restitution)
+                .build();
+            colliders.insert(collider);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ball_falls_under_gravity() {
+        let course = Course::generate(42);
+        let mut phys = Physics::new(&course, [5.0, 20.0, 25.0]);
+        for _ in 0..12 {
+            phys.step(FIXED_DT);
+        }
+        let s = phys.ball_state();
+        assert!(s.pos[2] < 25.0, "ball should fall, z={}", s.pos[2]);
+        assert!(s.pos[2] > 19.0, "ball should not tunnel, z={}", s.pos[2]);
+    }
+
+    #[test]
+    fn ball_rests_on_flat_tee() {
+        let course = Course::generate(42);
+        let mut phys = Physics::new(&course, [5.5, 20.0, 20.2]);
+        for _ in 0..180 {
+            phys.step(FIXED_DT);
+        }
+        let s = phys.ball_state();
+        assert!(s.at_rest, "ball should come to rest on flat tee");
+        assert!(
+            (s.pos[2] - (20.0 + BALL_RADIUS)).abs() < 0.1,
+            "ball rest z should be ~{}, got {}",
+            20.0 + BALL_RADIUS,
+            s.pos[2]
+        );
+    }
+
+    #[test]
+    fn launch_imparts_velocity() {
+        let course = Course::generate(42);
+        let mut phys = Physics::new(&course, [5.5, 20.0, 20.2]);
+        phys.launch([5.0, 0.0, 0.0]);
+        let s = phys.ball_state();
+        assert!(
+            (s.vel[0] - 5.0).abs() < 1e-3,
+            "vx should be ~5.0, got {}",
+            s.vel[0]
+        );
+    }
+
+    #[test]
+    fn triangulation_matches_heightmap_at_corners() {
+        let course = Course::generate(42);
+        let x = 60;
+        let y = 20;
+        let h = course.cell_heights(x, y);
+        let tris = cell_triangles(&course, x, y);
+        // tri[0] = NW, tri[1] = NE, tri[2] = SE
+        assert!((tris[0][0].z as f64 - h.floor[0]).abs() < 1e-6);
+        assert!((tris[0][1].z as f64 - h.floor[1]).abs() < 1e-6);
+        assert!((tris[0][2].z as f64 - h.floor[3]).abs() < 1e-6);
+        // tri2[0] = NW, tri2[1] = SE, tri2[2] = SW
+        assert!((tris[1][0].z as f64 - h.floor[0]).abs() < 1e-6);
+        assert!((tris[1][1].z as f64 - h.floor[3]).abs() < 1e-6);
+        assert!((tris[1][2].z as f64 - h.floor[2]).abs() < 1e-6);
+    }
+
+    #[test]
+    fn at_rest_becomes_true_after_stop() {
+        let course = Course::generate(42);
+        let mut phys = Physics::new(&course, [5.5, 20.0, 20.05]);
+        for _ in 0..120 {
+            phys.step(FIXED_DT);
+        }
+        assert!(phys.ball_state().at_rest);
+    }
+}

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -103,7 +103,7 @@ impl Physics {
 
     /// 実時間 `dt` 秒分ぶん物理を進める。内部では `1/60s` 固定ステップで回す。
     ///
-    /// 蓄積した実時間は [`MAX_ACCUMULATED_DT`] でクランプする。スリープ・
+    /// 蓄積した実時間は `MAX_ACCUMULATED_DT` (0.25s) でクランプする。スリープ・
     /// デバッガ停止などで巨大な `dt` が入ってきても、アキュムレータの while
     /// ループが CPU を焼き切る spiral-of-death を起こさない。
     pub fn step(&mut self, dt: f64) {


### PR DESCRIPTION
## 関連 Issue

closes #3

## 概要

rapier3d 剛体シミュレーションと termray 描画を繋ぎ、ボールを空間に飛ばせる状態にする Phase 2 実装。

## 変更内容

### 新規モジュール
- **`src/physics.rs`** — rapier3d `World` + `RigidBody` + `Collider` 基盤。`Course` の corner heights からタイル種別ごとに 7 本の `TriMesh` コライダーを構築（`(NW,NE,SE)+(NW,SE,SW)` の三角形分割、Issue 設計メモ準拠）。外周 `TILE_WALL` セルには垂直 `Cuboid` も立て、ボールがマップ外に抜けないようにする。ボールは `r=0.021m / m=0.046kg / CCD on`。固定タイムステップ 60Hz（描画レート非依存のアキュムレータ）。`at_rest` = `|linvel|<0.05 ∧ |angvel|<0.1` が 0.5 秒連続。
- **`src/camera_follow.rs`** — `FollowCam` 3人称追従。MVP は `ShotStanding`（ボール後方 5m・高さ +2m・見下ろし -0.15rad）。`Flying` / `FirstPerson` は enum として定義済みで、実装は `ShotStanding` にフォールバック（Phase 3/6 で差し替え）。
- **`examples/shot_test.rs`** — 1打ハードコードテスト。ティーにボールをスポーン → 0.5秒後に `launch([12, 0, 4])` → ボール追跡 → 静止まで。ピン（赤）+ ボール（白）の 2 スプライトを termray に渡す。

### タイル摩擦・反発設定

| タイル | friction | restitution |
|---|---|---|
| TEE | 0.3 | 0.15 |
| FAIRWAY | 0.3 | 0.2 |
| ROUGH | 0.5 | 0.2 |
| BUNKER | 0.9 | 0.05 |
| GREEN | 0.1 | 0.1 |
| WATER | 0.2 | 0.3 |
| WALL | 0.4 | 0.3 |

### 設計不変項

**三角形分割**: 1セル = 2三角形 `(NW,NE,SE)+(NW,SE,SW)`。termray 側の ray-floor 交差と同じ分割にすることで、描画と衝突判定がピクセル単位でズレない（Issue 設計メモ準拠）。

**Z-up 座標系**: rapier3d のデフォルト（Y-up）ではなく termray に合わせて Z-up。gravity = `(0, 0, -9.81)`。

**f64/f32 境界**: 公開 API は f64、内部で rapier3d の `Real = f32` に変換。

### ドキュメント
- `README.md` / `CLAUDE.md`: Current phase を Phase 2 に更新、`cargo run --release --example shot_test` 追記
- `CHANGELOG.md`: `## [Unreleased]` `### Added` に 3 モジュール追記
- `docs/architecture.md`: Phase 2 セクション（三角形分割の不変項とアキュムレータパターン）

## テスト

```
29 passed; 0 failed (+5 新規)
```

新規 5 テスト（physics.rs）:
- `ball_falls_under_gravity` — 重力で z が減少
- `ball_rests_on_flat_tee` — ティー上で 3 秒後に at_rest=true
- `launch_imparts_velocity` — launch 直後の linvel が入力値
- `triangulation_matches_heightmap_at_corners` — trimesh 頂点の z が `cell_heights().floor` と完全一致
- `at_rest_becomes_true_after_stop` — 静止 0.5 秒で at_rest=true

`cargo clippy --all-targets -- -D warnings` zero warnings。

## 既知の制約

- **ウォーターハザードに垂直壁コライダーなし** — 水面は -0.2m、周辺フェアウェイは約 0m なので現状は重力で自然にカバーされている。将来厳密な水没判定が必要になれば外周 WALL と同じく垂直 Cuboid を追加する。
- **Flying / FirstPerson はスタブ** — enum のみ定義、計算は ShotStanding に流用。Phase 3 以降で実装差し替え。
- **`src/main.rs` は Phase 0 スプラッシュのまま** — Phase 3 (#4) のショット入力ループが入るまで据え置き。

## 次フェーズ

Phase 3 (#4): ショット入力（クラブ選択・狙い・パワー）と shot → ball-flight → rest シーケンス。本 PR の `Physics::launch` をそのまま使う。