### PR TITLE
Phase 4: ホールアウト判定 + スコア + ラウンド終了 (MVP v0.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ All notable changes to street-golf are documented in this file. The format is ba
 ## [Unreleased]
 
 ### Added
+- Phase 4 hole-out + score card + round end
+  ([#5](https://github.com/kako-jun/street-golf/issues/5)).
+  Phase 4 の完了で **MVP v0.1.0** としての 1 ホール分のプレイアブル体験が
+  揃った（crates.io 公開は別 Issue で扱う）。`src/round.rs` に
+  `RoundState` を追加し、`ParSelect → Playing → Finished` の 3 ステートで
+  進行管理する。`check_hole_out` はカップ半径 5.4cm（R&A/USGA 規格の
+  10.8cm 直径）と速度上限 2m/s の AND 条件で skim-over を防ぎ、
+  `score_label` は Hole in One / Albatross / Eagle / Birdie / Par / Bogey /
+  Double Bogey / Triple Bogey / Over を返す。`Physics::teleport_ball`
+  と `Course::pin_world_pos` を追加し、水タイルで静止すれば 1 打罰して
+  発射位置に戻す。`main.rs` は Par 選択画面（Par 3 / 4 / 5）、プレイ中の
+  スコア HUD、ホールアウト後の結果ダイアログ（framebuffer 中央を薄暗く
+  してオーバーレイ + ストローク履歴）、`Y` でのリトライ（Par は維持）を
+  実装。21 件のユニットテスト（round）+ 2 件（physics / course）を追加、
+  合計 69 件が通る。
+
 - Phase 3 shot input + swing sequence
   ([#4](https://github.com/kako-jun/street-golf/issues/4)).
   `src/shot.rs` introduces the pure-logic `ShotState` machine with four phases
@@ -48,9 +64,14 @@ All notable changes to street-golf are documented in this file. The format is ba
   `softprops/action-gh-release@v2`).
 
 ### Changed
+- `src/main.rs` は Phase 3 のショットループを `RoundState` でラップした
+  3 フェーズ制に拡張。Par 選択 → ショットループ → 結果画面 → リトライの
+  全フローが動く。HUD 行数を 3 → 8 に拡張（結果画面の履歴表示用）。
 - `src/main.rs` replaces the Phase 0 800ms splash with the full Phase 3 game
   loop: input → state tick → physics step → camera update → render → HUD.
   `cargo run --release` is now the playable binary.
 
 ### Notes
+- Phase 4 完了で MVP v0.1.0 相当の遊びが揃ったが、crates.io への公開は
+  別 Issue（Phase 5+ でまとめて扱う）。タグは `[Unreleased]` のまま据え置き。
 - `examples/shot_test.rs` は Phase 2 のハードコード発射検証として据え置き。`ShotState` とは独立。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Single-crate binary depending on the external [`termray`](https://github.com/kak
 - `src/course.rs` (Phase 1 — 実装済) — `Course`: implements `termray::TileMap` + `termray::HeightMap`. Hand-drawn 200×40 layout with tee / fairway / rough / bunkers / water / green + pin. Per-corner floor heights are precomputed with a seed-derived low-frequency noise base, a flat 20m rooftop tee, a water surface at -0.2m (solid), and a green bowl centered on the pin.
 - `src/physics.rs` (Phase 2) — rapier3d rigid-body world, ball state, course collider generation, step-and-sample integration
 - `src/shot.rs` (Phase 3 — 実装済) — `ShotState` ステートマシン (`Aiming` / `PowerSwinging` / `Flight` / `AtRest`)、`Club` / `ClubSpec` テーブル、自己振動するパワーメーター、launch 速度計算。純粋ロジックでユニットテストのみ
-- `src/hud.rs` (Phase 4) — score card, club picker, wind / distance / lie indicators
+- `src/round.rs` (Phase 4 — 実装済) — `RoundState` ステートマシン (`ParSelect` / `Playing` / `Finished`)、`check_hole_out` 判定（カップ半径 + 速度上限）、`score_label`、ストローク履歴 `StrokeRecord`、集計 `RoundResult`。Par 選択 / 水ペナルティ / リトライを含む。純粋ロジック
 
 termray (external) owns raycasting: DDA walls, per-column ray-floor intersection, sprite and label projection. street-golf injects golf semantics (course surface heights, ball sprite, hole pin label) into termray through its trait-based hooks, while rapier3d owns the ball's trajectory and the camera rides along.
 
@@ -27,18 +27,21 @@ cargo fmt --all
 
 ## Current phase
 
-Phase 3 — shot input + swing sequence. `src/shot.rs` introduces `ShotState` として `Aiming → PowerSwinging → Flight → AtRest` の 4 ステート機を純粋ロジックで持つ。パワーメーターは `PowerSwinging` 中に 0→1→0 の三角波で自己振動し、Space 2 回押し（開始・停止）で値を確定する方式（crossterm の KeyRelease はポータブルに取れないため press/release 方式を避けた）。`Club` は Driver / 3I / 5I / 7I / 9I / PW / SW / Putter の 8 本を用意し `'1'..='8'` キーで切り替える。`src/main.rs` は Phase 0 スプラッシュを捨て、`Physics` + `FollowCam` + termray を駆動するフルゲームループに置き換わった。`cargo run --release` でティーからピンまで実際に何打か打って到達できる。ホールアウト判定・スコア確定は Phase 4 (#5) に続く。
+Phase 4 — ホールアウト判定 + スコアカード + ラウンド終了。MVP v0.1.0 としての遊び切れる 1 ホールが完成した。`src/round.rs` に `RoundState` を追加し、`ParSelect → Playing → Finished` の 3 ステートで進行管理する。起動直後に Par 3 / 4 / 5 を選び、`Playing` フェーズで Phase 3 のショットループが回る。ボールが静止するたびにカップ判定（半径 5.4cm 以内 **かつ** 速度 2m/s 未満）と水ペナルティ判定（`TILE_WATER` で静止 → +1 打 + 発射位置に復帰）を挟み、ホールインすれば `Finished` に遷移して最終スコア（Hole in One / Albatross / Eagle / Birdie / Par / Bogey / …）とストローク履歴を表示する。`Y` でリトライ（Par は維持）、`N` / `Esc` で終了。`examples/shot_test.rs` は Phase 2 の物理検証用ハーネスとして据え置き。
 
 ### 操作キー
 
-| キー | 効果 |
-|---|---|
-| `1`-`8` | クラブ選択（Driver / 3I / 5I / 7I / 9I / PW / SW / Putter） |
-| `a` / `d` | yaw（水平方向）を ±約 2° |
-| `w` / `s` | pitch（打ち出し角）を ±2°（0°-45° クランプ） |
-| `Space` | Aiming→PowerSwinging→Flight、AtRest→Aiming |
-| `x` | PowerSwinging→Aiming（スイングをキャンセル） |
-| `Esc` | 終了 |
+| キー | フェーズ | 効果 |
+|---|---|---|
+| `3` / `4` / `5` | ParSelect | Par 3 / 4 / 5 を選んで Playing に遷移 |
+| `1`-`8` | Playing | クラブ選択（Driver / 3I / 5I / 7I / 9I / PW / SW / Putter） |
+| `a` / `d` | Playing | yaw（水平方向）を ±約 2° |
+| `w` / `s` | Playing | pitch（打ち出し角）を ±2°（0°-45° クランプ） |
+| `Space` | Playing | Aiming→PowerSwinging→Flight、AtRest→Aiming |
+| `x` | Playing | PowerSwinging→Aiming（スイングをキャンセル） |
+| `Y` | Finished | 同じ Par でリトライ |
+| `N` | Finished | 終了 |
+| `Esc` | 全フェーズ | 終了 |
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 TUI street golf — tee off from a rooftop, land on the street, keep playing until you hole out.
 
-> **Status**: Pre-alpha. Phase 3 adds the playable shot loop — aim, choose a club, time the power meter, and watch the ball fly until it rests. Scoring and hole-out still land in Phase 4.
+> **Status**: MVP v0.1.0 — a single playable hole. Phase 4 completes the loop: choose par, play until you hole out, see your score, retry or quit. crates.io publish is tracked separately.
 
 ## Stack
 
@@ -15,25 +15,38 @@ TUI street golf — tee off from a rooftop, land on the street, keep playing unt
 
 ```bash
 cargo build --release
-cargo run --release                          # Phase 3 playable shot loop (main binary)
+cargo run --release                          # Phase 4 playable single hole (main binary)
 cargo run --release --example fly_through    # Phase 1 walk-through of the synthetic course
 cargo run --release --example shot_test      # Phase 2 hardcoded 1-shot physics verification
 ```
 
-`cargo run --release` now launches the playable game: you tee off from the rooftop, pick a club, aim, and time the power meter to hit the ball toward the pin. The `fly_through` example still walks the 200×40 synthetic course; the `shot_test` example remains a hardcoded launch verification harness for the physics pipeline.
+`cargo run --release` launches the playable game: pick a par, tee off from the rooftop, aim, and time the power meter to hit the ball toward the pin. Land it in the cup (radius 5.4cm, speed under 2 m/s) to hole out; land it in water for a 1-stroke penalty and replay from where you teed the shot from.
+
+## Gameplay
+
+1. **Par select screen** — choose Par 3 / 4 / 5 with the `3` / `4` / `5` key. The Phase 1 synthetic course is tuned for Par 4 (~185m tee-to-pin) but all three are playable.
+2. **Shot loop** — aim with `a` / `d` (yaw) and `w` / `s` (pitch), pick a club with `1`-`8`, then:
+   - Press `Space` once — the power meter starts oscillating 0 → 100% → 0% on a 2.4s triangle wave.
+   - Press `Space` again — whichever value is showing at that instant becomes the shot's strength, and the ball flies.
+   - `x` during the power swing cancels back to aim.
+3. **Ball at rest** — after the ball stops, the HUD shows its lie (fairway / rough / green / bunker / tee) and recommends the putter on the green. Press `Space` to start the next shot.
+4. **Water penalty** — if the ball comes to rest on a water tile, you take a 1-stroke penalty and the ball is teleported back to where you teed this shot from.
+5. **Hole out** — once the ball ends inside the cup (5.4cm radius) at under 2 m/s, the round ends. The HUD shows your score (Hole in One / Albatross / Eagle / Birdie / Par / Bogey / …) plus a stroke-by-stroke recap.
+6. **Retry or quit** — press `Y` to play the same par again, or `N` / `Esc` to exit.
 
 ### Controls
 
-| Key | Effect |
-|---|---|
-| `1`-`8` | Club: Driver / 3I / 5I / 7I / 9I / PW / SW / Putter |
-| `a` / `d` | Yaw left / right (~2°) |
-| `w` / `s` | Pitch up / down (0°-45°) |
-| `Space` | Aim → start swing → release → (after rest) back to aim |
-| `x` | Cancel the current swing (PowerSwinging → Aiming) |
-| `Esc` | Quit |
-
-The power meter auto-oscillates from 0% to 100% and back. Press `Space` once to start the swing and a second time to release — whichever power value is displayed at that instant is the shot's strength.
+| Key | Phase | Effect |
+|---|---|---|
+| `3` / `4` / `5` | Par select | Pick par and start playing |
+| `1`-`8` | Playing | Club: Driver / 3I / 5I / 7I / 9I / PW / SW / Putter |
+| `a` / `d` | Playing | Yaw left / right (~2°) |
+| `w` / `s` | Playing | Pitch up / down (0°-45°) |
+| `Space` | Playing | Aim → start swing → release → (after rest) back to aim |
+| `x` | Playing | Cancel the current swing (PowerSwinging → Aiming) |
+| `Y` | Finished | Retry with the same par |
+| `N` | Finished | Quit |
+| `Esc` | Any | Quit |
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ cargo run --release --example shot_test      # Phase 2 hardcoded 1-shot physics 
 
 ## Gameplay
 
+水ハザードでボールが止まると +1 打ペナルティでショット開始位置に戻る。
+スコアラベル (Birdie/Par 等) はストローク数のみで判定し、ペナルティは Total と vs Par に反映される。
+
 1. **Par select screen** — choose Par 3 / 4 / 5 with the `3` / `4` / `5` key. The Phase 1 synthetic course is tuned for Par 4 (~185m tee-to-pin) but all three are playable.
 2. **Shot loop** — aim with `a` / `d` (yaw) and `w` / `s` (pitch), pick a club with `1`-`8`, then:
    - Press `Space` once — the power meter starts oscillating 0 → 100% → 0% on a 2.4s triangle wave.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -203,3 +203,55 @@ The 201 × 41 corner grid is shared between adjacent tiles, so each corner is cl
 | [`anyhow`](https://crates.io/crates/anyhow) | 1 | Error propagation in the binary |
 
 The dependency list is deliberately minimal. Phase 5+ will add OSM / SRTM parsers when real-world data import begins.
+
+## Phase 4 — round management
+
+`src/round.rs` ではプレイヤーのラウンドをモデル化する。`Physics` や `ShotState`
+には手を入れず、既存のステートを `RoundState` でラップして進行を追いかける
+スタイルを取った。
+
+### State machine
+
+```
+ ┌──────────────┐  '3'/'4'/'5'  ┌──────────┐  hole out   ┌──────────┐
+ │ ParSelect    │ ────────────► │ Playing  │ ──────────► │ Finished │
+ └──────────────┘               └──────────┘             └──────────┘
+                                     ▲                        │
+                                     │     'Y' (retry)        │
+                                     └────────────────────────┘
+```
+
+- `ParSelect`（開始直後） — `3` / `4` / `5` で Par を選ぶ。`Esc` で終了。
+- `Playing` — Phase 3 のショットループがそのまま回る。加えて Flight → AtRest
+  遷移のタイミングでカップ判定・水ペナルティ判定・ストローク履歴追加を挟む。
+- `Finished` — `Y` でリトライ（Par は維持）、`N` / `Esc` で終了。
+
+### Hole-out check
+
+カップは `Course::pin_world_pos()` で取得した 3D 座標を中心とする円盤で、
+水平距離が `CUP_RADIUS_M = 0.054m` 以下（R&A/USGA 規格 4.25in 直径）**かつ**
+速度が `HOLE_OUT_SPEED_LIMIT = 2.0 m/s` 未満のとき "ホールイン" と判定する。
+2 条件の AND で skim-over（カップを高速で横切る）を除外する。
+
+### Water penalty
+
+水タイル (`TILE_WATER`) で静止した場合は 1 打罰して発射位置
+(`round.last_start_pos`) に `Physics::teleport_ball` でボールを戻す。線速度・
+角速度はゼロ化するのでそのまま次のショット入力に入れる。ホールインして
+いない場合のみ発動する。
+
+### Score label table
+
+| strokes vs par | ラベル |
+|---|---|
+| `strokes == 1`（Par 問わず） | Hole in One |
+| `-3` 以下 | Albatross |
+| `-2` | Eagle |
+| `-1` | Birdie |
+| `0` | Par |
+| `+1` | Bogey |
+| `+2` | Double Bogey |
+| `+3` | Triple Bogey |
+| `+4` 以上 | Over |
+
+`vs_par` は `strokes + penalties - par` で計算する（ペナルティも合算）。

--- a/src/course.rs
+++ b/src/course.rs
@@ -104,6 +104,18 @@ impl Course {
         (PIN_X, PIN_Y)
     }
 
+    /// ピン位置の 3D ワールド座標 `[x, y, z]`。Z はピンが属するセルのコーナー
+    /// 高さから bilinear サンプルで取る。ホールアウト判定で使う。
+    pub fn pin_world_pos(&self) -> [f64; 3] {
+        let (px, py) = self.pin();
+        let cx = px.floor() as i32;
+        let cy = py.floor() as i32;
+        let u = px - cx as f64;
+        let v = py - cy as f64;
+        let z = self.cell_heights(cx, cy).sample_floor(u, v);
+        [px, py, z]
+    }
+
     /// ティーから打つときのカメラ初期位置 (x, y, z)。
     /// z はルーフトップ高さ + アイレベル。
     pub fn tee_spawn(&self) -> (f64, f64, f64) {
@@ -405,6 +417,22 @@ mod tests {
         assert!((x - 5.0).abs() < 1e-9);
         assert!((y - 20.0).abs() < 1e-9);
         assert!((z - (TEE_FLOOR_HEIGHT + EYE_HEIGHT)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn pin_world_pos_matches_heights() {
+        let c = Course::generate(42);
+        let [px, py, pz] = c.pin_world_pos();
+        assert!((px - PIN_X).abs() < 1e-9);
+        assert!((py - PIN_Y).abs() < 1e-9);
+        // ピンは (190.5, 20.5)。cx=190, cy=20, u=v=0.5。
+        let expected_z = c.cell_heights(190, 20).sample_floor(0.5, 0.5);
+        assert!(
+            (pz - expected_z).abs() < 1e-9,
+            "z={} expected={}",
+            pz,
+            expected_z
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,18 +3,24 @@
 //! Phase 1 ではコース定義（[`course`]）を導入する。ティー・フェアウェイ・
 //! バンカー・ウォーターハザード・グリーン・ピンをレイアウトした 200m × 40m の
 //! 合成コースを [`termray::TileMap`] / [`termray::HeightMap`] として公開し、
-//! `cargo run --example fly_through` で歩き回れる。以降のフェーズでは
-//! ボール物理（`physics`）、ショット入力（`shot`）、HUD（`hud`）を追加予定。
+//! `cargo run --example fly_through` で歩き回れる。Phase 2 でボール物理
+//! ([`physics`])、Phase 3 でショット入力 ([`shot`])、Phase 4 でラウンド進行
+//! ([`round`]) を追加。
 
 pub mod camera_follow;
 pub mod collide;
 pub mod course;
 pub mod physics;
+pub mod round;
 pub mod shot;
 
 pub use camera_follow::{FollowCam, FollowMode};
 pub use collide::{step_x, step_y};
 pub use course::{Course, TILE_BUNKER, TILE_FAIRWAY, TILE_GREEN, TILE_ROUGH, TILE_TEE, TILE_WATER};
 pub use physics::{BallState, Physics};
+pub use round::{
+    CUP_RADIUS_M, HOLE_OUT_SPEED_LIMIT, RoundPhase, RoundResult, RoundState, StrokeRecord,
+    check_hole_out, score_label,
+};
 pub use shot::{Club, ClubSpec, ShotPhase, ShotState};
 pub use termray::{TILE_EMPTY, TILE_VOID, TILE_WALL};

--- a/src/main.rs
+++ b/src/main.rs
@@ -342,27 +342,39 @@ fn play_hud(
 }
 
 /// Finished フェーズの HUD 文字列。結果サマリ + ストローク履歴 + 操作案内。
+///
+/// 行数の内訳は厳密に `HEADER_ROWS + log_budget + FOOTER_ROWS == HUD_ROWS`。
+/// 履歴が `log_budget` を超える場合は末尾 1 行を `... (+N more)` 要約で潰し、
+/// フッタ（Retry/Quit 行）は常に確保する。以前は先に履歴を全部積んでから
+/// `truncate(HUD_ROWS)` していたため、長いラウンドでフッタが消え、プレイヤーが
+/// ソフトロック状態に見える不具合があった。
 fn end_hud(result: &RoundResult, log: &[StrokeRecord], width: usize) -> String {
+    // 行配分: ヘッダ 2 + ログ 5 + フッタ 1 = HUD_ROWS (= 8)。
+    const HEADER_ROWS: usize = 2;
+    const FOOTER_ROWS: usize = 1;
+    let log_budget = HUD_ROWS - HEADER_ROWS - FOOTER_ROWS;
+    debug_assert_eq!(HEADER_ROWS + log_budget + FOOTER_ROWS, HUD_ROWS);
+
     let sign = if result.vs_par > 0 {
         format!("+{}", result.vs_par)
     } else {
         result.vs_par.to_string()
     };
     let line0 = "========== Round Complete ==========".to_string();
-    // フォーマット方針: "Hole in {total} strokes" で打数とペナルティ込みの合計を
-    // 冒頭に出す。スコアラベル (Birdie/Par 等) はストローク数のみで判定し、
-    // カッコ内の vs Par はペナルティ込みの合計と Par の差分なので、両者が
-    // 食い違うケース（例: Birdie (+1)）はペナルティが 1 以上のときに発生する。
-    // フッタの "Label based on strokes only" 行で注記する。
+    // フォーマット方針: "Holed out in {total} (strokes: S + penalties: P)!" で
+    // 合計打数 = 物理ストローク + ペナルティを明示し、"strokes" の曖昧さを消す。
+    // スコアラベル (Birdie/Par 等) はストローク数のみで判定するので、vs Par
+    // （ペナルティ込みの total と Par の差）と Label が食い違うケースがある
+    // （例: Birdie (+1)）。フッタの注記で明示する。
     let line1 = format!(
-        "Hole in {} strokes!  Par {} -> {} ({}) [Penalties: {}, Total: {}]",
-        result.total, result.par, result.label, sign, result.penalties, result.total,
+        "Holed out in {} (strokes: {} + penalties: {})!  Par {} -> {} ({})",
+        result.total, result.strokes, result.penalties, result.par, result.label, sign,
     );
-    // ストローク履歴は最大 5 行まで（それ以上は省略）。
-    let max_log_rows = 5;
-    let mut log_lines: Vec<String> = log
+
+    // ストローク履歴は log_budget 行まで。超える場合は最後 1 行を "... (+N more)"
+    // 要約で置き換える（履歴 log_budget-1 行 + 要約 1 行 = log_budget）。
+    let formatted: Vec<String> = log
         .iter()
-        .take(max_log_rows)
         .map(|s| {
             let spec = s.club.spec();
             let rest = tile_name(s.rest_tile);
@@ -377,9 +389,15 @@ fn end_hud(result: &RoundResult, log: &[StrokeRecord], width: usize) -> String {
             )
         })
         .collect();
-    if log.len() > max_log_rows {
-        log_lines.push(format!("  ... (+{} more)", log.len() - max_log_rows));
-    }
+    let log_lines: Vec<String> = if formatted.len() <= log_budget {
+        formatted
+    } else {
+        let keep = log_budget - 1;
+        let mut v: Vec<String> = formatted.iter().take(keep).cloned().collect();
+        v.push(format!("  ... (+{} more)", formatted.len() - keep));
+        v
+    };
+
     // Label は strokes のみで判定するため、Penalties 付きの vs Par と Label が
     // 食い違うことがある（例: Birdie (+1)）。プレイヤー向けに注記する。
     let footer =
@@ -389,14 +407,12 @@ fn end_hud(result: &RoundResult, log: &[StrokeRecord], width: usize) -> String {
     lines.push(line0);
     lines.push(line1);
     lines.extend(log_lines);
-    while lines.len() < HUD_ROWS - 1 {
+    // ログが log_budget 未満の場合は空行でフッタ位置を下げる。
+    while lines.len() < HEADER_ROWS + log_budget {
         lines.push(String::new());
     }
     lines.push(footer);
-    while lines.len() < HUD_ROWS {
-        lines.push(String::new());
-    }
-    lines.truncate(HUD_ROWS);
+    debug_assert_eq!(lines.len(), HUD_ROWS);
     pad_lines(&lines, width)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,10 @@
-//! street-golf — Phase 3 のプレイアブルゲームループ。
+//! street-golf — Phase 4 のプレイアブルゲームループ。
 //!
-//! ティーからピンまでの 1 ホールを、クラブ選択 + 狙い + パワーの入力で
-//! 何打かに分けて攻める。crossterm でキー入力を取り、[`ShotState`] と
-//! [`Physics`] を駆動し、termray の半ブロック描画で毎フレームを present する。
-//! ホールアウト判定とスコア確定は Phase 4 (#5) で追加予定。
+//! Par 選択（`ParSelect`）→ ショットループ（`Playing`）→ 結果画面（`Finished`）
+//! の 3 フェーズを crossterm 入力 + [`RoundState`] で駆動する。`Playing` 中の
+//! ショット確定→物理ステップ→追従カメラ→描画→HUD の流れは Phase 3 と同じ
+//! で、加えて at-rest 遷移時にカップ判定と水ペナルティを挟み、ホールイン
+//! すれば `Finished` に進んで最終スコアを表示する。
 
 use std::io::{Write, stdout};
 use std::time::{Duration, Instant};
@@ -21,8 +22,8 @@ use crossterm::terminal::{
 };
 
 use street_golf::{
-    Course, FollowCam, FollowMode, Physics, TILE_BUNKER, TILE_FAIRWAY, TILE_GREEN, TILE_ROUGH,
-    TILE_TEE, TILE_WATER,
+    Course, FollowCam, FollowMode, Physics, RoundPhase, RoundResult, RoundState, StrokeRecord,
+    TILE_BUNKER, TILE_FAIRWAY, TILE_GREEN, TILE_ROUGH, TILE_TEE, TILE_WATER, check_hole_out,
     shot::{Club, PITCH_STEP_DEG, ShotPhase, ShotState, YAW_STEP_RAD},
 };
 use termray::{
@@ -39,8 +40,9 @@ const BALL_SPRITE_TYPE: u8 = 2;
 /// `Physics::AT_REST_DURATION` (0.5s) と合わせて、launch から AtRest まで
 /// 最低 1 秒未満は絶対にならない。片方を上げるときはもう片方も再考すること。
 const FLIGHT_REST_HOLD_SEC: f64 = 0.5;
-/// HUD に予約する行数。
-const HUD_ROWS: usize = 3;
+/// HUD に予約する行数。Par 選択画面 / プレイ中 / 結果画面すべてで共通。
+/// 結果画面が最大行数を要するのでそれに合わせた。
+const HUD_ROWS: usize = 8;
 /// メインループのターゲット fps (≈60Hz)。
 const FRAME_SLEEP: Duration = Duration::from_millis(16);
 /// `course.tee_spawn()` が tee 面に足すアイレベル（カメラ視点の高さ）。
@@ -153,54 +155,89 @@ impl Drop for TerminalGuard {
     }
 }
 
-/// 入力ハンドラの返り値。`Launch` は `Physics::launch` を呼ぶタイミング。
+/// 入力ハンドラの返り値（Playing 用）。`Launch` は `Physics::launch` を呼ぶ
+/// タイミング。発射位置を `RoundState::start_stroke` に渡すため呼び出し側
+/// で `ball_state` を参照する。
 #[must_use]
-enum Action {
+enum PlayAction {
     Continue,
     Quit,
     Launch([f64; 3]),
 }
 
-fn handle_key(shot: &mut ShotState, code: KeyCode) -> Action {
+fn handle_play_key(shot: &mut ShotState, code: KeyCode) -> PlayAction {
     // `q` / `e` は将来のスピン入力 (backspin / topspin) に予約。終了は Esc のみ。
     match code {
-        KeyCode::Esc => Action::Quit,
+        KeyCode::Esc => PlayAction::Quit,
         KeyCode::Char(' ') => {
             let launched = shot.press_space();
             if launched {
-                Action::Launch(shot.compute_launch_velocity())
+                PlayAction::Launch(shot.compute_launch_velocity())
             } else {
-                Action::Continue
+                PlayAction::Continue
             }
         }
         KeyCode::Char('a') => {
             shot.adjust_yaw(-YAW_STEP_RAD);
-            Action::Continue
+            PlayAction::Continue
         }
         KeyCode::Char('d') => {
             shot.adjust_yaw(YAW_STEP_RAD);
-            Action::Continue
+            PlayAction::Continue
         }
         KeyCode::Char('w') => {
             shot.adjust_pitch(PITCH_STEP_DEG);
-            Action::Continue
+            PlayAction::Continue
         }
         KeyCode::Char('s') => {
             shot.adjust_pitch(-PITCH_STEP_DEG);
-            Action::Continue
+            PlayAction::Continue
         }
         KeyCode::Char('x') => {
             shot.press_cancel();
-            Action::Continue
+            PlayAction::Continue
         }
         KeyCode::Char(c) => {
             if let Some(club) = Club::from_digit(c) {
                 shot.select_club(club);
             }
-            Action::Continue
+            PlayAction::Continue
         }
-        _ => Action::Continue,
+        _ => PlayAction::Continue,
     }
+}
+
+/// ParSelect フェーズで受け付けるキー。`Some(par)` で Par 確定、`None` で
+/// 入力継続、`Err` で終了要求。
+fn handle_par_select_key(code: KeyCode) -> ParAction {
+    match code {
+        KeyCode::Esc => ParAction::Quit,
+        KeyCode::Char(c @ ('3' | '4' | '5')) => ParAction::Select(c.to_digit(10).unwrap()),
+        _ => ParAction::Continue,
+    }
+}
+
+#[must_use]
+enum ParAction {
+    Continue,
+    Quit,
+    Select(u32),
+}
+
+/// Finished フェーズで受け付けるキー。
+fn handle_end_key(code: KeyCode) -> EndAction {
+    match code {
+        KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('N') => EndAction::Quit,
+        KeyCode::Char('y') | KeyCode::Char('Y') => EndAction::Retry,
+        _ => EndAction::Continue,
+    }
+}
+
+#[must_use]
+enum EndAction {
+    Continue,
+    Quit,
+    Retry,
 }
 
 fn tile_name(tile: Option<TileType>) -> &'static str {
@@ -216,8 +253,25 @@ fn tile_name(tile: Option<TileType>) -> &'static str {
     }
 }
 
-fn hud(
+/// Par 選択画面の HUD 文字列。
+fn par_select_hud(width: usize) -> String {
+    let lines = [
+        "========== street-golf ==========".to_string(),
+        "Course: Phase 1 synthetic (seed 42)".to_string(),
+        "Select par:".to_string(),
+        "  [3] Par 3   (~130m)".to_string(),
+        "  [4] Par 4   (~185m)  <-- recommended".to_string(),
+        "  [5] Par 5   (~220m)".to_string(),
+        "Esc: Quit".to_string(),
+        String::new(),
+    ];
+    pad_lines(&lines, width)
+}
+
+/// Playing フェーズの HUD 文字列（4 本のコンテンツ行 + padding）。
+fn play_hud(
     shot: &ShotState,
+    round: &RoundState,
     ball_pos: [f64; 3],
     ball_vel: [f64; 3],
     course: &Course,
@@ -230,6 +284,11 @@ fn hud(
     let spec = shot.club.spec();
     let yaw_deg = shot.yaw.to_degrees();
     let pitch_deg = shot.effective_pitch_deg();
+    let total = round.strokes + round.penalties;
+    let line0 = format!(
+        "Par {} | Strokes: {} | Penalties: {} | Total: {}",
+        round.par, round.strokes, round.penalties, total,
+    );
     let line1 = format!(
         "Club: {} (loft {:.0}°, max {:.0}m/s) | Shots: {} | Yaw: {:+.1}° Pitch: {:.1}° | Tile: {}",
         spec.label, spec.loft_deg, spec.max_speed_mps, shot.shots, yaw_deg, pitch_deg, tile_label,
@@ -266,8 +325,74 @@ fn hud(
         }
     };
     let line3 = "Keys: 1-8=club  a/d=yaw  w/s=pitch  space=shoot  x=cancel  esc=quit".to_string();
+    let lines = [
+        line0,
+        line1,
+        line2,
+        line3,
+        String::new(),
+        String::new(),
+        String::new(),
+        String::new(),
+    ];
+    pad_lines(&lines, width)
+}
+
+/// Finished フェーズの HUD 文字列。結果サマリ + ストローク履歴 + 操作案内。
+fn end_hud(result: &RoundResult, log: &[StrokeRecord], width: usize) -> String {
+    let sign = if result.vs_par > 0 {
+        format!("+{}", result.vs_par)
+    } else {
+        result.vs_par.to_string()
+    };
+    let line0 = "========== Round Complete ==========".to_string();
+    let line1 = format!(
+        "Hole in {}!  Par {} -> {} ({}) [Penalties: {}, Total: {}]",
+        result.strokes, result.par, result.label, sign, result.penalties, result.total,
+    );
+    // ストローク履歴は最大 5 行まで（それ以上は省略）。
+    let max_log_rows = 5;
+    let mut log_lines: Vec<String> = log
+        .iter()
+        .take(max_log_rows)
+        .map(|s| {
+            let spec = s.club.spec();
+            let rest = tile_name(s.rest_tile);
+            let pen = if s.penalty { "  [WATER +1]" } else { "" };
+            format!(
+                "  {}: {:<6} power {:>3}%  -> {}{}",
+                s.index,
+                spec.label,
+                (s.power * 100.0).round() as i32,
+                rest,
+                pen,
+            )
+        })
+        .collect();
+    if log.len() > max_log_rows {
+        log_lines.push(format!("  ... (+{} more)", log.len() - max_log_rows));
+    }
+    let footer = "[Y] Retry   [N/Esc] Quit".to_string();
+
+    let mut lines: Vec<String> = Vec::with_capacity(HUD_ROWS);
+    lines.push(line0);
+    lines.push(line1);
+    lines.extend(log_lines);
+    while lines.len() < HUD_ROWS - 1 {
+        lines.push(String::new());
+    }
+    lines.push(footer);
+    while lines.len() < HUD_ROWS {
+        lines.push(String::new());
+    }
+    lines.truncate(HUD_ROWS);
+    pad_lines(&lines, width)
+}
+
+/// 行配列を width で truncate / pad し、`\r\n` で連結する（末尾改行なし）。
+fn pad_lines(lines: &[String], width: usize) -> String {
     let mut out = String::new();
-    for (i, line) in [line1, line2, line3].iter().enumerate() {
+    for (i, line) in lines.iter().enumerate() {
         let mut s = line.clone();
         // HUD 文字列は ASCII 前提。日本語タイル名が混ざる場合は unicode-width を導入すること。
         if s.chars().count() > width {
@@ -279,11 +404,39 @@ fn hud(
             }
         }
         out.push_str(&s);
-        if i + 1 < 3 {
+        if i + 1 < lines.len() {
             out.push_str("\r\n");
         }
     }
     out
+}
+
+/// Finished フェーズ用に framebuffer 中央を薄暗くする（ダイアログ背景）。
+fn dim_center(fb: &mut Framebuffer) {
+    let w = fb.width();
+    let h = fb.height();
+    if w == 0 || h == 0 {
+        return;
+    }
+    let box_w = (w * 6 / 10).min(w);
+    let box_h = (h * 6 / 10).min(h);
+    let x0 = w.saturating_sub(box_w) / 2;
+    let y0 = h.saturating_sub(box_h) / 2;
+    for y in y0..(y0 + box_h).min(h) {
+        for x in x0..(x0 + box_w).min(w) {
+            let p = fb.get_pixel(x, y);
+            // 暗めにブレンド（40% を残す）。
+            fb.set_pixel(
+                x,
+                y,
+                Color::rgb(
+                    (p.r as u32 * 40 / 100) as u8,
+                    (p.g as u32 * 40 / 100) as u8,
+                    (p.b as u32 * 40 / 100) as u8,
+                ),
+            );
+        }
+    }
 }
 
 fn present(fb: &Framebuffer, status: &str) -> std::io::Result<()> {
@@ -338,6 +491,7 @@ fn main() -> Result<()> {
     let mut physics = Physics::new(&course, ball_spawn);
     let mut shot = ShotState::new(0.0);
     let mut follow = FollowCam::new(FollowMode::ShotStanding, 0.0);
+    let mut round = RoundState::new(ball_spawn);
 
     let mut cam = Camera::with_z(tee_x, tee_y, tee_z, 0.0, 70f64.to_radians());
     let mut fb = Framebuffer::new(fb_w, fb_h);
@@ -352,57 +506,122 @@ fn main() -> Result<()> {
         let dt = (now - last).as_secs_f64().min(0.05);
         last = now;
 
+        // --- 入力処理（フェーズ別）---
         while poll(Duration::from_millis(0))? {
             if let Event::Key(key) = read()? {
-                match handle_key(&mut shot, key.code) {
-                    Action::Continue => {}
-                    Action::Quit => return Ok(()),
-                    Action::Launch(v) => {
-                        physics.launch(v);
-                        flight_timer = 0.0;
-                    }
+                match round.phase {
+                    RoundPhase::ParSelect => match handle_par_select_key(key.code) {
+                        ParAction::Continue => {}
+                        ParAction::Quit => return Ok(()),
+                        ParAction::Select(p) => round.select_par(p),
+                    },
+                    RoundPhase::Playing => match handle_play_key(&mut shot, key.code) {
+                        PlayAction::Continue => {}
+                        PlayAction::Quit => return Ok(()),
+                        PlayAction::Launch(v) => {
+                            let ball_now = physics.ball_state();
+                            round.start_stroke(ball_now.pos);
+                            physics.launch(v);
+                            flight_timer = 0.0;
+                        }
+                    },
+                    RoundPhase::Finished => match handle_end_key(key.code) {
+                        EndAction::Continue => {}
+                        EndAction::Quit => return Ok(()),
+                        EndAction::Retry => {
+                            physics = Physics::new(&course, ball_spawn);
+                            shot = ShotState::new(0.0);
+                            follow = FollowCam::new(FollowMode::ShotStanding, 0.0);
+                            round.retry(ball_spawn);
+                            flight_timer = 0.0;
+                        }
+                    },
                 }
             }
         }
 
+        // --- 物理・状態更新 ---
         shot.tick(dt);
         physics.step(dt);
 
         let ball = physics.ball_state();
+
+        // Flight → AtRest 遷移時にカップ判定 + 水ペナルティ + 履歴記録。
         if shot.phase == ShotPhase::Flight {
             flight_timer += dt;
-            if ball.at_rest && flight_timer > FLIGHT_REST_HOLD_SEC {
-                shot.notify_rest();
-                flight_timer = 0.0;
+        }
+        if round.phase == RoundPhase::Playing
+            && shot.phase == ShotPhase::Flight
+            && ball.at_rest
+            && flight_timer > FLIGHT_REST_HOLD_SEC
+        {
+            let pin = course.pin_world_pos();
+            let holed = check_hole_out(&ball, pin);
+            let tile = course.tile_at(ball.pos[0].floor() as i32, ball.pos[1].floor() as i32);
+            let penalty = !holed && tile == Some(TILE_WATER);
+            round.record_stroke(
+                shot.club,
+                shot.power,
+                round.last_start_pos,
+                ball.pos,
+                tile,
+                penalty,
+            );
+            if holed {
+                round.finish();
+            } else if penalty {
+                physics.teleport_ball(round.last_start_pos);
             }
+            shot.notify_rest();
+            flight_timer = 0.0;
         }
 
+        // --- カメラ更新 ---
         follow.yaw = shot.yaw;
         let (ccx, ccy, ccz, cyaw, cpitch) = follow.update(ball.pos);
         cam.set_pose(ccx, ccy, cyaw);
         cam.set_z(ccz);
         cam.set_pitch(cpitch);
 
+        // --- 描画 ---
         fb.clear(Color::default());
         let rays = cam.cast_all_rays(&course, fb_w, MAX_DISTANCE);
         render_floor_ceiling(&mut fb, &rays, &scene, &course, &cam, MAX_DISTANCE);
         render_walls(&mut fb, &rays, &scene, &course, &cam, MAX_DISTANCE);
-        let sprites = [
-            Sprite {
-                x: pin_x,
-                y: pin_y,
-                sprite_type: PIN_SPRITE_TYPE,
-            },
-            Sprite {
+        // ホールアウト後はボールを消す（カップに落ちた演出）。
+        let mut sprites: Vec<Sprite> = Vec::with_capacity(2);
+        sprites.push(Sprite {
+            x: pin_x,
+            y: pin_y,
+            sprite_type: PIN_SPRITE_TYPE,
+        });
+        if !round.holed_out {
+            sprites.push(Sprite {
                 x: ball.pos[0],
                 y: ball.pos[1],
                 sprite_type: BALL_SPRITE_TYPE,
-            },
-        ];
+            });
+        }
         let projected = project_sprites(&sprites, &cam, &course, fb_w, fb_h);
         render_sprites(&mut fb, &projected, &rays, &art, MAX_DISTANCE);
 
-        present(&fb, &hud(&shot, ball.pos, ball.vel, &course, fb_w))?;
+        // Finished フェーズはダイアログ背景として中央を暗くする。
+        if round.phase == RoundPhase::Finished {
+            dim_center(&mut fb);
+        }
+
+        // --- HUD / ステータス ---
+        let status = match round.phase {
+            RoundPhase::ParSelect => par_select_hud(fb_w),
+            RoundPhase::Playing => play_hud(&shot, &round, ball.pos, ball.vel, &course, fb_w),
+            RoundPhase::Finished => {
+                // result は finish() で必ず埋まっている。
+                let result = round.result.as_ref().expect("result after finish");
+                end_hud(result, &round.stroke_log, fb_w)
+            }
+        };
+
+        present(&fb, &status)?;
         std::thread::sleep(FRAME_SLEEP);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,8 +40,8 @@ const BALL_SPRITE_TYPE: u8 = 2;
 /// `Physics::AT_REST_DURATION` (0.5s) と合わせて、launch から AtRest まで
 /// 最低 1 秒未満は絶対にならない。片方を上げるときはもう片方も再考すること。
 const FLIGHT_REST_HOLD_SEC: f64 = 0.5;
-/// HUD に予約する行数。Par 選択画面 / プレイ中 / 結果画面すべてで共通。
-/// 結果画面が最大行数を要するのでそれに合わせた。
+/// HUD と End ダイアログ共通の高さ。End ダイアログが 8 行（ヘッダ + 最大 5
+/// 履歴 + フッタ）を必要とするため、ゲーム中の Playing HUD もそれに合わせる。
 const HUD_ROWS: usize = 8;
 /// メインループのターゲット fps (≈60Hz)。
 const FRAME_SLEEP: Duration = Duration::from_millis(16);
@@ -198,6 +198,7 @@ fn handle_play_key(shot: &mut ShotState, code: KeyCode) -> PlayAction {
             PlayAction::Continue
         }
         KeyCode::Char(c) => {
+            // '3'..='5' は Par 選択画面でも使うが、Playing 中はクラブ切替として処理される。
             if let Some(club) = Club::from_digit(c) {
                 shot.select_club(club);
             }
@@ -268,7 +269,9 @@ fn par_select_hud(width: usize) -> String {
     pad_lines(&lines, width)
 }
 
-/// Playing フェーズの HUD 文字列（4 本のコンテンツ行 + padding）。
+/// Playing フェーズの HUD 文字列。`HUD_ROWS=8` で Par 選択画面 / プレイ中 /
+/// End 画面すべて同じ行数に揃える。Playing は 4 本のコンテンツ行 + 4 本の
+/// パディング、End は最大 5 本のストローク履歴 + ヘッダ + フッタ = 8。
 fn play_hud(
     shot: &ShotState,
     round: &RoundState,
@@ -346,9 +349,14 @@ fn end_hud(result: &RoundResult, log: &[StrokeRecord], width: usize) -> String {
         result.vs_par.to_string()
     };
     let line0 = "========== Round Complete ==========".to_string();
+    // フォーマット方針: "Hole in {total} strokes" で打数とペナルティ込みの合計を
+    // 冒頭に出す。スコアラベル (Birdie/Par 等) はストローク数のみで判定し、
+    // カッコ内の vs Par はペナルティ込みの合計と Par の差分なので、両者が
+    // 食い違うケース（例: Birdie (+1)）はペナルティが 1 以上のときに発生する。
+    // フッタの "Label based on strokes only" 行で注記する。
     let line1 = format!(
-        "Hole in {}!  Par {} -> {} ({}) [Penalties: {}, Total: {}]",
-        result.strokes, result.par, result.label, sign, result.penalties, result.total,
+        "Hole in {} strokes!  Par {} -> {} ({}) [Penalties: {}, Total: {}]",
+        result.total, result.par, result.label, sign, result.penalties, result.total,
     );
     // ストローク履歴は最大 5 行まで（それ以上は省略）。
     let max_log_rows = 5;
@@ -372,7 +380,10 @@ fn end_hud(result: &RoundResult, log: &[StrokeRecord], width: usize) -> String {
     if log.len() > max_log_rows {
         log_lines.push(format!("  ... (+{} more)", log.len() - max_log_rows));
     }
-    let footer = "[Y] Retry   [N/Esc] Quit".to_string();
+    // Label は strokes のみで判定するため、Penalties 付きの vs Par と Label が
+    // 食い違うことがある（例: Birdie (+1)）。プレイヤー向けに注記する。
+    let footer =
+        "[Y] Retry  [N/Esc] Quit  (Label based on strokes only; penalties excluded)".to_string();
 
     let mut lines: Vec<String> = Vec::with_capacity(HUD_ROWS);
     lines.push(line0);
@@ -531,6 +542,7 @@ fn main() -> Result<()> {
                         EndAction::Retry => {
                             physics = Physics::new(&course, ball_spawn);
                             shot = ShotState::new(0.0);
+                            // shot.yaw も 0.0 に戻るので yaw 0.0 を渡して問題ない。
                             follow = FollowCam::new(FollowMode::ShotStanding, 0.0);
                             round.retry(ball_spawn);
                             flight_timer = 0.0;
@@ -542,7 +554,11 @@ fn main() -> Result<()> {
 
         // --- 物理・状態更新 ---
         shot.tick(dt);
-        physics.step(dt);
+        // Finished はボールが完全停止しているので物理ステップをスキップする。
+        // ball_state() は状態を読むだけなのでカメラ追従は引き続き機能する。
+        if !matches!(round.phase, RoundPhase::Finished) {
+            physics.step(dt);
+        }
 
         let ball = physics.ball_state();
 

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -170,6 +170,20 @@ impl Physics {
         );
         self.at_rest_timer = 0.0;
     }
+
+    /// ボールを指定位置にテレポートし、線形・角速度をゼロ化する。
+    /// 停止タイマーもリセットするので、直後のフレームから自然にステップを
+    /// 再開できる。水ペナルティ（1打罰して発射位置に戻す）やリトライで使う。
+    pub fn teleport_ball(&mut self, pos: [f64; 3]) {
+        let body = &mut self.bodies[self.ball_handle];
+        body.set_translation(
+            Vector::new(pos[0] as f32, pos[1] as f32, pos[2] as f32),
+            true,
+        );
+        body.set_linvel(Vector::new(0.0, 0.0, 0.0), true);
+        body.set_angvel(Vector::new(0.0, 0.0, 0.0), true);
+        self.at_rest_timer = 0.0;
+    }
 }
 
 /// タイル種ごとの (friction, restitution) ペア。
@@ -343,6 +357,30 @@ mod tests {
             elapsed
         );
         assert!(phys.time_accumulator < FIXED_DT);
+    }
+
+    #[test]
+    fn teleport_ball_moves_and_zeroes_velocity() {
+        let course = Course::generate(42);
+        let mut phys = Physics::new(&course, [5.5, 20.0, 20.5]);
+        // 少し落下させて速度を持たせる。
+        phys.step(0.1);
+        let before = phys.ball_state();
+        assert!(
+            before.vel[2] < 0.0,
+            "ball should be falling, vz={}",
+            before.vel[2]
+        );
+
+        phys.teleport_ball([10.0, 10.0, 30.0]);
+        let after = phys.ball_state();
+        assert!((after.pos[0] - 10.0).abs() < 1e-4, "pos.x={}", after.pos[0]);
+        assert!((after.pos[1] - 10.0).abs() < 1e-4, "pos.y={}", after.pos[1]);
+        assert!((after.pos[2] - 30.0).abs() < 1e-4, "pos.z={}", after.pos[2]);
+        assert!(after.vel[0].abs() < 1e-6);
+        assert!(after.vel[1].abs() < 1e-6);
+        assert!(after.vel[2].abs() < 1e-6);
+        assert!(!after.at_rest, "at_rest timer should be reset");
     }
 
     #[test]

--- a/src/round.rs
+++ b/src/round.rs
@@ -178,9 +178,13 @@ pub fn check_hole_out(ball: &BallState, pin: [f64; 3]) -> bool {
 }
 
 /// ストローク数と Par からスコアラベルを決める。`strokes == 1` は Par に
-/// かかわらず常に "Hole in One"。
+/// かかわらず常に "Hole in One"。`strokes == 0` は API 契約違反だが、
+/// panic せず `(n/a)` を返して公開 API を堅牢にする（呼び出し側の不正入力で
+/// ゲームがクラッシュしない保険）。
 pub fn score_label(strokes: u32, par: u32) -> &'static str {
-    debug_assert!(strokes >= 1, "score_label requires strokes >= 1");
+    if strokes == 0 {
+        return "(n/a)";
+    }
     if strokes == 1 {
         return "Hole in One";
     }
@@ -282,6 +286,15 @@ mod tests {
     fn score_label_over() {
         assert_eq!(score_label(9, 4), "Over");
         assert_eq!(score_label(12, 5), "Over");
+    }
+
+    /// `strokes=0` は API 契約違反だが panic せず `(n/a)` を返すことを確認する。
+    /// 公開 API として呼び出し側の不正入力でクラッシュしないための堅牢化。
+    #[test]
+    fn score_label_zero_strokes_returns_na() {
+        assert_eq!(score_label(0, 3), "(n/a)");
+        assert_eq!(score_label(0, 4), "(n/a)");
+        assert_eq!(score_label(0, 5), "(n/a)");
     }
 
     #[test]

--- a/src/round.rs
+++ b/src/round.rs
@@ -98,7 +98,9 @@ impl RoundState {
     }
 
     /// ショット結果を履歴に追加する。`penalty=true` なら `penalties` も +1。
-    /// ホールインしたなら end_pos 記録後に [`RoundState::finish`] を別途呼ぶ。
+    /// `record_stroke` でストロークを記録した後、ホールインと判定できた
+    /// ときに別途 [`RoundState::finish`] を呼ぶ。phase が `Playing` でない
+    /// 場合は no-op。
     pub fn record_stroke(
         &mut self,
         club: Club,
@@ -178,6 +180,7 @@ pub fn check_hole_out(ball: &BallState, pin: [f64; 3]) -> bool {
 /// ストローク数と Par からスコアラベルを決める。`strokes == 1` は Par に
 /// かかわらず常に "Hole in One"。
 pub fn score_label(strokes: u32, par: u32) -> &'static str {
+    debug_assert!(strokes >= 1, "score_label requires strokes >= 1");
     if strokes == 1 {
         return "Hole in One";
     }
@@ -404,6 +407,36 @@ mod tests {
         assert_eq!(r.strokes, 0);
         assert_eq!(r.penalties, 0);
         assert!(r.stroke_log.is_empty());
+        assert!(!r.holed_out);
+        assert!(r.result.is_none());
+    }
+
+    #[test]
+    fn retry_from_playing_resets_cleanly() {
+        // finish() を経由せず Playing から直接 retry() した場合もきれいに
+        // リセットされることを担保する回帰テスト。
+        let tee = [5.0, 20.0, 20.0];
+        let mut r = RoundState::new(tee);
+        r.select_par(4);
+        r.start_stroke(tee);
+        r.record_stroke(Club::Driver, 0.9, tee, [90.0, 20.0, 0.5], None, true);
+        r.record_stroke(
+            Club::Iron7,
+            0.8,
+            [90.0, 20.0, 0.5],
+            [140.0, 20.0, 0.3],
+            None,
+            false,
+        );
+        assert_eq!(r.strokes, 2);
+        assert_eq!(r.penalties, 1);
+
+        r.retry(tee);
+        assert_eq!(r.phase, RoundPhase::Playing);
+        assert_eq!(r.strokes, 0);
+        assert_eq!(r.penalties, 0);
+        assert_eq!(r.stroke_log.len(), 0);
+        assert_eq!(r.par, 4);
         assert!(!r.holed_out);
         assert!(r.result.is_none());
     }

--- a/src/round.rs
+++ b/src/round.rs
@@ -1,0 +1,433 @@
+//! Phase 4 のラウンド進行管理。
+//!
+//! 1 ホールのプレイ全体を `ParSelect → Playing → Finished` の 3 ステートで
+//! 追いかけ、打数・ペナルティ・ストローク履歴・最終結果を保持する。
+//! ホールアウト判定はカップ半径と速度上限の 2 条件でスキムオーバーを防ぐ。
+//! 純粋ロジックでユニットテストだけでカバーできる。
+
+use termray::TileType;
+
+use crate::BallState;
+use crate::shot::Club;
+
+/// カップの半径 (m)。R&A/USGA 規格はカップ直径 4.25 inch = 10.8 cm。
+pub const CUP_RADIUS_M: f64 = 0.054;
+
+/// ホールイン判定に使う速度上限 (m/s)。これより速いとカップを弾いて通過
+/// するためホールインにしない（"skim over" 対策）。
+pub const HOLE_OUT_SPEED_LIMIT: f64 = 2.0;
+
+/// ラウンドのフェーズ。
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum RoundPhase {
+    /// Par を選ぶ初期画面。3 / 4 / 5 キーで [`RoundPhase::Playing`] に進む。
+    ParSelect,
+    /// プレイ中。ショットループが回る。
+    Playing,
+    /// ホールアウト後。Y でリトライ、N / Esc で終了。
+    Finished,
+}
+
+/// 1 ストロークの記録。
+#[derive(Clone, Debug)]
+pub struct StrokeRecord {
+    /// 1 始まりのストローク番号。ペナルティは別カウント。
+    pub index: u32,
+    pub club: Club,
+    pub power: f64,
+    pub start_pos: [f64; 3],
+    pub end_pos: [f64; 3],
+    pub rest_tile: Option<TileType>,
+    pub penalty: bool,
+}
+
+/// ラウンド終了時の集計。
+#[derive(Clone, Debug)]
+pub struct RoundResult {
+    pub par: u32,
+    pub strokes: u32,
+    pub penalties: u32,
+    pub total: u32,
+    pub vs_par: i32,
+    pub label: &'static str,
+}
+
+/// ラウンド全体の状態。
+pub struct RoundState {
+    pub phase: RoundPhase,
+    pub par: u32,
+    pub strokes: u32,
+    pub penalties: u32,
+    pub stroke_log: Vec<StrokeRecord>,
+    pub holed_out: bool,
+    /// 次のショットの発射位置（= 現在のボール静止位置）。水ペナルティで
+    /// 戻す先としても使う。
+    pub last_start_pos: [f64; 3],
+    pub result: Option<RoundResult>,
+}
+
+impl RoundState {
+    /// ティー位置を渡して初期化する。Par は `ParSelect` で確定するまで仮値 4。
+    pub fn new(tee_pos: [f64; 3]) -> Self {
+        Self {
+            phase: RoundPhase::ParSelect,
+            par: 4,
+            strokes: 0,
+            penalties: 0,
+            stroke_log: Vec::new(),
+            holed_out: false,
+            last_start_pos: tee_pos,
+            result: None,
+        }
+    }
+
+    /// `'3'`/`'4'`/`'5'` の入力を Par として受け付けて [`RoundPhase::Playing`]
+    /// に遷移する。範囲外や他フェーズからは no-op。
+    pub fn select_par(&mut self, par: u32) {
+        if self.phase == RoundPhase::ParSelect && (3..=5).contains(&par) {
+            self.par = par;
+            self.phase = RoundPhase::Playing;
+        }
+    }
+
+    /// ショット確定時（`Flight` 遷移直前）に呼ぶ。発射位置を記録する。
+    pub fn start_stroke(&mut self, start_pos: [f64; 3]) {
+        if self.phase == RoundPhase::Playing {
+            self.last_start_pos = start_pos;
+        }
+    }
+
+    /// ショット結果を履歴に追加する。`penalty=true` なら `penalties` も +1。
+    /// ホールインしたなら end_pos 記録後に [`RoundState::finish`] を別途呼ぶ。
+    pub fn record_stroke(
+        &mut self,
+        club: Club,
+        power: f64,
+        start_pos: [f64; 3],
+        end_pos: [f64; 3],
+        rest_tile: Option<TileType>,
+        penalty: bool,
+    ) {
+        if self.phase != RoundPhase::Playing {
+            return;
+        }
+        self.strokes += 1;
+        if penalty {
+            self.penalties += 1;
+        }
+        self.stroke_log.push(StrokeRecord {
+            index: self.strokes,
+            club,
+            power,
+            start_pos,
+            end_pos,
+            rest_tile,
+            penalty,
+        });
+    }
+
+    /// ホールアウトしたときに呼ぶ。`result` を埋めて [`RoundPhase::Finished`]
+    /// に遷移する。
+    pub fn finish(&mut self) {
+        if self.phase != RoundPhase::Playing {
+            return;
+        }
+        self.holed_out = true;
+        let total = self.strokes + self.penalties;
+        let vs_par = total as i32 - self.par as i32;
+        let label = score_label(self.strokes, self.par);
+        self.result = Some(RoundResult {
+            par: self.par,
+            strokes: self.strokes,
+            penalties: self.penalties,
+            total,
+            vs_par,
+            label,
+        });
+        self.phase = RoundPhase::Finished;
+    }
+
+    /// リトライ: Par を保持したままスコアとログをリセットして `Playing` に
+    /// 戻す。ParSelect には戻らない（仕様: Par 再選択なし）。
+    pub fn retry(&mut self, tee_pos: [f64; 3]) {
+        self.phase = RoundPhase::Playing;
+        self.strokes = 0;
+        self.penalties = 0;
+        self.stroke_log.clear();
+        self.holed_out = false;
+        self.last_start_pos = tee_pos;
+        self.result = None;
+    }
+}
+
+/// ホールイン判定。水平距離がカップ半径以下 **かつ** 速度が
+/// [`HOLE_OUT_SPEED_LIMIT`] 未満のとき `true`。境界は inclusive（距離
+/// そのもので比較するので `dx²+dy²` と `r²` を二乗演算した浮動小数の丸め
+/// で境界テストが落ちないように `<= r + ε` に統一する）。
+pub fn check_hole_out(ball: &BallState, pin: [f64; 3]) -> bool {
+    let dx = ball.pos[0] - pin[0];
+    let dy = ball.pos[1] - pin[1];
+    let horiz = (dx * dx + dy * dy).sqrt();
+    if horiz > CUP_RADIUS_M + 1e-9 {
+        return false;
+    }
+    let s2 = ball.vel[0].powi(2) + ball.vel[1].powi(2) + ball.vel[2].powi(2);
+    s2 < HOLE_OUT_SPEED_LIMIT * HOLE_OUT_SPEED_LIMIT
+}
+
+/// ストローク数と Par からスコアラベルを決める。`strokes == 1` は Par に
+/// かかわらず常に "Hole in One"。
+pub fn score_label(strokes: u32, par: u32) -> &'static str {
+    if strokes == 1 {
+        return "Hole in One";
+    }
+    let diff = strokes as i32 - par as i32;
+    match diff {
+        d if d <= -3 => "Albatross",
+        -2 => "Eagle",
+        -1 => "Birdie",
+        0 => "Par",
+        1 => "Bogey",
+        2 => "Double Bogey",
+        3 => "Triple Bogey",
+        _ => "Over",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ball(pos: [f64; 3], vel: [f64; 3]) -> BallState {
+        BallState {
+            pos,
+            vel,
+            at_rest: false,
+        }
+    }
+
+    const PIN: [f64; 3] = [190.5, 20.5, 0.0];
+
+    #[test]
+    fn check_hole_out_within_radius_and_slow() {
+        let b = ball([PIN[0] + 0.03, PIN[1], PIN[2]], [0.5, 0.0, 0.0]);
+        assert!(check_hole_out(&b, PIN));
+    }
+
+    #[test]
+    fn check_hole_out_just_outside_radius() {
+        let b = ball([PIN[0] + 0.06, PIN[1], PIN[2]], [0.5, 0.0, 0.0]);
+        assert!(!check_hole_out(&b, PIN));
+    }
+
+    #[test]
+    fn check_hole_out_too_fast_skims_over() {
+        let b = ball([PIN[0] + 0.02, PIN[1], PIN[2]], [3.0, 0.0, 0.0]);
+        assert!(!check_hole_out(&b, PIN));
+    }
+
+    #[test]
+    fn check_hole_out_at_exact_radius_boundary() {
+        let b = ball([PIN[0] + CUP_RADIUS_M, PIN[1], PIN[2]], [0.0, 0.0, 0.0]);
+        assert!(check_hole_out(&b, PIN));
+    }
+
+    #[test]
+    fn score_label_hole_in_one_overrides_par() {
+        assert_eq!(score_label(1, 3), "Hole in One");
+        assert_eq!(score_label(1, 4), "Hole in One");
+        assert_eq!(score_label(1, 5), "Hole in One");
+    }
+
+    #[test]
+    fn score_label_par() {
+        assert_eq!(score_label(3, 3), "Par");
+        assert_eq!(score_label(4, 4), "Par");
+        assert_eq!(score_label(5, 5), "Par");
+    }
+
+    #[test]
+    fn score_label_birdie() {
+        assert_eq!(score_label(3, 4), "Birdie");
+        assert_eq!(score_label(4, 5), "Birdie");
+    }
+
+    #[test]
+    fn score_label_eagle() {
+        assert_eq!(score_label(2, 4), "Eagle");
+        assert_eq!(score_label(3, 5), "Eagle");
+    }
+
+    #[test]
+    fn score_label_albatross() {
+        // par 5 の 3 打 → Albatross。par 4 の 1 打は "Hole in One" が優先。
+        assert_eq!(score_label(2, 5), "Albatross");
+    }
+
+    #[test]
+    fn score_label_bogey() {
+        assert_eq!(score_label(5, 4), "Bogey");
+    }
+
+    #[test]
+    fn score_label_double_and_triple_bogey() {
+        assert_eq!(score_label(6, 4), "Double Bogey");
+        assert_eq!(score_label(7, 4), "Triple Bogey");
+    }
+
+    #[test]
+    fn score_label_over() {
+        assert_eq!(score_label(9, 4), "Over");
+        assert_eq!(score_label(12, 5), "Over");
+    }
+
+    #[test]
+    fn round_state_new_starts_in_par_select() {
+        let r = RoundState::new([5.0, 20.0, 20.0]);
+        assert_eq!(r.phase, RoundPhase::ParSelect);
+        assert_eq!(r.strokes, 0);
+        assert_eq!(r.penalties, 0);
+        assert!(!r.holed_out);
+        assert!(r.result.is_none());
+    }
+
+    #[test]
+    fn select_par_transitions_to_playing() {
+        let mut r = RoundState::new([5.0, 20.0, 20.0]);
+        r.select_par(4);
+        assert_eq!(r.phase, RoundPhase::Playing);
+        assert_eq!(r.par, 4);
+    }
+
+    #[test]
+    fn select_par_out_of_range_noop() {
+        let mut r = RoundState::new([5.0, 20.0, 20.0]);
+        r.select_par(6);
+        assert_eq!(r.phase, RoundPhase::ParSelect);
+        r.select_par(2);
+        assert_eq!(r.phase, RoundPhase::ParSelect);
+    }
+
+    #[test]
+    fn record_stroke_appends_log_and_increments() {
+        let mut r = RoundState::new([5.0, 20.0, 20.0]);
+        r.select_par(4);
+        r.record_stroke(
+            Club::Driver,
+            0.9,
+            [5.0, 20.0, 20.0],
+            [80.0, 20.0, 0.5],
+            Some(4),
+            false,
+        );
+        assert_eq!(r.strokes, 1);
+        assert_eq!(r.penalties, 0);
+        assert_eq!(r.stroke_log.len(), 1);
+        assert_eq!(r.stroke_log[0].index, 1);
+        assert_eq!(r.stroke_log[0].club, Club::Driver);
+    }
+
+    #[test]
+    fn record_stroke_with_penalty_increments_penalties() {
+        let mut r = RoundState::new([5.0, 20.0, 20.0]);
+        r.select_par(4);
+        r.record_stroke(
+            Club::Iron7,
+            0.8,
+            [5.0, 20.0, 20.0],
+            [107.0, 19.0, -0.2],
+            Some(8),
+            true,
+        );
+        assert_eq!(r.strokes, 1);
+        assert_eq!(r.penalties, 1);
+    }
+
+    #[test]
+    fn finish_computes_result_with_vs_par() {
+        let mut r = RoundState::new([5.0, 20.0, 20.0]);
+        r.select_par(4);
+        r.record_stroke(
+            Club::Driver,
+            0.9,
+            [5.0, 20.0, 20.0],
+            [90.0, 20.0, 0.5],
+            None,
+            false,
+        );
+        r.record_stroke(
+            Club::Iron7,
+            0.8,
+            [90.0, 20.0, 0.5],
+            [170.0, 20.0, 0.3],
+            None,
+            false,
+        );
+        r.record_stroke(
+            Club::Putter,
+            0.3,
+            [170.0, 20.0, 0.3],
+            [190.5, 20.5, 0.0],
+            None,
+            false,
+        );
+        r.finish();
+        assert_eq!(r.phase, RoundPhase::Finished);
+        let res = r.result.as_ref().unwrap();
+        assert_eq!(res.par, 4);
+        assert_eq!(res.strokes, 3);
+        assert_eq!(res.penalties, 0);
+        assert_eq!(res.total, 3);
+        assert_eq!(res.vs_par, -1);
+        assert_eq!(res.label, "Birdie");
+        assert!(r.holed_out);
+    }
+
+    #[test]
+    fn retry_resets_strokes_keeps_par() {
+        let mut r = RoundState::new([5.0, 20.0, 20.0]);
+        r.select_par(5);
+        r.record_stroke(
+            Club::Driver,
+            0.9,
+            [5.0, 20.0, 20.0],
+            [90.0, 20.0, 0.5],
+            None,
+            false,
+        );
+        r.finish(); // strokes=1 → "Hole in One"
+        assert_eq!(r.phase, RoundPhase::Finished);
+
+        r.retry([5.0, 20.0, 20.0]);
+        assert_eq!(r.phase, RoundPhase::Playing);
+        assert_eq!(r.par, 5);
+        assert_eq!(r.strokes, 0);
+        assert_eq!(r.penalties, 0);
+        assert!(r.stroke_log.is_empty());
+        assert!(!r.holed_out);
+        assert!(r.result.is_none());
+    }
+
+    #[test]
+    fn start_stroke_updates_last_start_pos() {
+        let mut r = RoundState::new([5.0, 20.0, 20.0]);
+        r.select_par(4);
+        r.start_stroke([50.0, 20.0, 0.4]);
+        assert_eq!(r.last_start_pos, [50.0, 20.0, 0.4]);
+    }
+
+    #[test]
+    fn record_stroke_ignored_outside_playing() {
+        let mut r = RoundState::new([5.0, 20.0, 20.0]);
+        // まだ ParSelect。
+        r.record_stroke(
+            Club::Driver,
+            0.5,
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            None,
+            false,
+        );
+        assert_eq!(r.strokes, 0);
+    }
+}


### PR DESCRIPTION
## 関連 Issue

closes #5

## 概要

street-golf MVP v0.1.0 完成。ホールアウト判定・スコアカード・Par 選択・リトライを追加し、1ホールのラウンドが完結するゲームに仕上げた。

## 変更内容

### 新規モジュール
- **`src/round.rs`** — ラウンドステートマシン（純粋ロジック、433行、21 ユニットテスト）
  - `RoundPhase { ParSelect, Playing, Finished }`
  - `RoundState`: par / strokes / penalties / stroke_log / holed_out / last_start_pos
  - `StrokeRecord` / `RoundResult`
  - `check_hole_out(ball, pin)` — カップ半径 0.054m + |vel| < 2 m/s
  - `score_label(strokes, par)` — Hole in One（strokes=1 は par 問わず）/ Albatross / Eagle / Birdie / Par / Bogey / Double Bogey / Triple Bogey / Over

### `src/physics.rs` 追加
- **`Physics::teleport_ball([f64;3])`** — ボールの位置・速度リセット（水ペナルティ用）

### `src/course.rs` 追加
- **`Course::pin_world_pos() -> [f64;3]`** — ピンの3Dワールド座標（床高さを bilinear サンプル）

### `src/main.rs` ラウンドループ化
3 フェーズ状態遷移:
- **ParSelect**: `[3]/[4]/[5]` で Par 選択
- **Playing**: Phase 3 のショットループ + ホールアウト判定 + 水ペナルティ（WATER タイル上で静止 → +1 打 + ショット開始位置テレポート）+ストローク記録
- **Finished**: End ダイアログ表示（Hole in N! / Par → ラベル / ストローク履歴 5件 / `[Y]` Retry `[N]` Quit）

### 定数
- `CUP_RADIUS_M = 0.054` (R&A/USGA 4.25in 直径)
- `HOLE_OUT_SPEED_LIMIT = 2.0` m/s (skim-over 防止)

### HUD 拡張
1行目にスコア行追加: \`Par 4 | Strokes: 3 | Penalties: 0 | Total: 3\`

### ドキュメント
- `CLAUDE.md`: Current phase を Phase 4 (MVP v0.1.0 完成) に、キー表に Par/Retry 追加
- `README.md`: 新規「Gameplay」節でフル体験フロー記述、キー表更新
- `CHANGELOG.md`: `### Added` に全新機能、v0.1.0 完成のノート（crates.io 公開は別Issue）
- `docs/architecture.md`: Phase 4 セクション（RoundState 状態遷移図、hole-out formula、water penalty flow、score label table）

## テスト

```
69 passed; 0 failed (+23 新規: physics 1 + course 1 + round 21)
```

主要テスト:
- `check_hole_out_within_radius_and_slow` / `just_outside_radius` / `too_fast_skims_over` / `at_exact_radius_boundary`
- `score_label_hole_in_one_overrides_par` / `par` / `birdie` / `eagle` / `albatross` / `bogey` / `over`
- `round_state_new_starts_in_par_select` / `select_par_transitions_to_playing` / `select_par_out_of_range_noop`
- `record_stroke_appends_log_and_increments` / `record_stroke_with_penalty_increments_penalties`
- `finish_computes_result_with_vs_par` / `retry_resets_strokes_keeps_par`
- `teleport_ball_moves_and_zeroes_velocity` / `pin_world_pos_matches_heights`

`cargo clippy --all-targets -- -D warnings` clean、`RUSTDOCFLAGS="-D warnings" cargo doc` clean。

## サブエージェント実装の plan 逸脱点

1. **`check_hole_out` 境界比較**: `horiz² > r²` がFP丸めで `AT_EXACT_RADIUS_BOUNDARY` テストで弾かれたため `sqrt` 方式に変更（`horiz > r + 1e-9`）。セマンティクス同一。
2. **HUD rows**: 4行 → 8行に拡張（End dialog でストローク履歴 5件分が必要）。短い端末では描画領域が減るが許容範囲。
3. **End dialog**: fb 中央を dim（輝度 40%）して背景にし、テキストはステータス行へ（複数行）。polished UI は Phase 5 以降で。
4. **ボール非表示**: ホールイン時は `round.holed_out` フラグで sprite をフィルタ。物理実体は残っている（MVP 割り切り）。
5. **リトライで Physics 再構築**: TriMesh を毎回作り直すのでスローPCでは一瞬停止する可能性あり。v0.1.0 では許容。

## v0.1.0 完成イメージ（Issue より）

- [x] `cargo run --release` で起動
- [x] ティーに立つ
- [x] パワーメーターでショット
- [x] 起伏のあるフェアウェイを転がる
- [x] グリーンでパター
- [x] ホールイン
- [x] スコア表示

3分で1ホール完結、`[Y]` でリトライ、`[N]` で終了。

## 次フェーズ

Phase 5+ (Issue #6 以降): OSM/SRTM 実データ取り込み → **金沢城+兼六園実地形再現**（v1.0 ビジョン）。本 PR の `Course::pin_world_pos` / `RoundState` はそのまま流用可能。